### PR TITLE
Refactor Registry Manager and Harvest to use ElasticSearch tech stack

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -3,7 +3,6 @@ package gov.nasa.pds.harvest;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -72,9 +71,15 @@ public class HarvestCli
     
     public void printHelp()
     {
-        HelpFormatter formatter = new HelpFormatter();
-        formatter.setWidth(100);
-        formatter.printHelp("harvest <options>", options);
+        System.out.println("Usage: harvest <options>");
+        System.out.println();
+        System.out.println("Required parameters:");
+        System.out.println("  -c <file>     Harvest configuration file");
+        System.out.println("Optional parameters:");
+        System.out.println("  -f <format>   Output format ('json' or 'xml'). Default is 'json'");
+        System.out.println("  -o <dir>      Output directory. Default is /tmp/harvest/out");
+        System.out.println("  -l <file>     Log file. Default is /tmp/harvest/harvest.log");
+        System.out.println("  -v <level>    Logger verbosity: 0=Debug, 1=Info (default), 2=Warning, 3=Error");
     }
 
     
@@ -107,22 +112,19 @@ public class HarvestCli
     {
         Option.Builder bld;
         
-        bld = Option.builder("c").hasArg().argName("file").desc("Harvest configuration file.").required();
+        bld = Option.builder("c").hasArg().argName("file").required();
         options.addOption(bld.build());
         
-        bld = Option.builder("o").hasArg().argName("dir")
-                .desc("Output directory for Solr or Elasticsearch documents. Default is /tmp/harvest/out");
+        bld = Option.builder("o").hasArg().argName("dir");
         options.addOption(bld.build());
 
-        bld = Option.builder("f").hasArg().argName("format")
-                .desc("Output format: 'es' (Elasticsearch JSON) or 'solr' (XML). Default is 'es'");
+        bld = Option.builder("f").hasArg().argName("format");
         options.addOption(bld.build());
         
-        bld = Option.builder("l").hasArg().argName("file").desc("Log file. Default is /tmp/harvest/harvest.log.");
+        bld = Option.builder("l").hasArg().argName("file");
         options.addOption(bld.build());
 
-        bld = Option.builder("v").hasArg().argName("level").
-                desc("Logger verbosity: 0=Debug, 1=Info (default), 2=Warning, 3=Error.");
+        bld = Option.builder("v").hasArg().argName("level");
         options.addOption(bld.build());
     }
 

--- a/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -88,7 +88,7 @@ public class HarvestCli
         }
         catch(ParseException ex)
         {
-            System.out.println("ERROR: " + ex.getMessage());
+            System.out.println("[ERROR] " + ex.getMessage());
             return false;
         }
     }
@@ -115,7 +115,7 @@ public class HarvestCli
         options.addOption(bld.build());
 
         bld = Option.builder("f").hasArg().argName("format")
-                .desc("Output format: 'solr' or 'es'. Default is 'solr'");
+                .desc("Output format: 'es' (Elasticsearch JSON) or 'solr' (XML). Default is 'es'");
         options.addOption(bld.build());
         
         bld = Option.builder("l").hasArg().argName("file").desc("Log file. Default is /tmp/harvest/harvest.log.");

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
@@ -36,7 +36,7 @@ public class CrawlerCommand
         fOutDir.mkdirs();
 
         // Output format
-        String outFormat = cmdLine.getOptionValue("f", "solr").toLowerCase();
+        String outFormat = cmdLine.getOptionValue("f", "es").toLowerCase();
         minLogger.info("Output format: " + outFormat);
 
         DocWriter writer = null;

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
@@ -36,17 +36,17 @@ public class CrawlerCommand
         fOutDir.mkdirs();
 
         // Output format
-        String outFormat = cmdLine.getOptionValue("f", "es").toLowerCase();
+        String outFormat = cmdLine.getOptionValue("f", "json").toLowerCase();
         minLogger.info("Output format: " + outFormat);
 
         DocWriter writer = null;
         
         switch(outFormat)
         {
-        case "solr":
+        case "xml":
             writer = new SolrDocWriter(fOutDir);
             break;
-        case "es":
+        case "json":
             writer = new EsDocWriter(fOutDir);
             break;
         default:

--- a/src/main/java/gov/nasa/pds/harvest/util/out/EsDocUtils.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/EsDocUtils.java
@@ -6,15 +6,21 @@ import com.google.gson.stream.JsonWriter;
 
 public class EsDocUtils
 {
+    private static final String REPLACE_DOT_WITH = "/";
+    
+    
     public static void writeField(JsonWriter jw, String key, String value) throws Exception
     {
         if(value == null) return;
+        
+        key = key.replaceAll("\\.", REPLACE_DOT_WITH);
         jw.name(key).value(value);
     }
 
 
     public static void writeField(JsonWriter jw, String key, long value) throws Exception
     {
+        key = key.replaceAll("\\.", REPLACE_DOT_WITH);
         jw.name(key).value(value);
     }
 
@@ -22,7 +28,8 @@ public class EsDocUtils
     public static void writeField(JsonWriter jw, String key, Collection<String> values) throws Exception
     {
         if(values == null || values.isEmpty()) return;
-        
+
+        key = key.replaceAll("\\.", REPLACE_DOT_WITH);
         jw.name(key);
 
         if(values.size() == 1)


### PR DESCRIPTION
Changed default output format to JSON (to import into Elasticsearch).
Replaced "." with "/" in field names in JSON output.
