### PR TITLE
Fixed NPE when a label, e.g., bundle, doesn't have any data/inventory files

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
@@ -67,8 +67,7 @@ public class CrawlerCommand
         minLogger.info("Reading configuration from " + pConfigFile);
         
         // Read config file
-        ConfigReader rd = new ConfigReader();
-        Configuration cfg = rd.read(cfgFile);
+        Configuration cfg = ConfigReader.read(cfgFile);
         
         // Load xpath maps from files
         XPathCacheLoader xpcLoader = new XPathCacheLoader();

--- a/src/main/java/gov/nasa/pds/harvest/meta/FileMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/FileMetadataExtractor.java
@@ -69,6 +69,8 @@ public class FileMetadataExtractor
     
     private void processDataFiles(File baseDir, Metadata meta) throws Exception
     {
+        if(meta == null || meta.dataFiles == null) return;
+        
         for(String fileName: meta.dataFiles)
         {
             File file = new File(baseDir, fileName);


### PR DESCRIPTION
Fixed NPE when a label, e.g., bundle, doesn't have any data/inventory files.
