### PR TITLE
Skip already registered products for new collections & product_lidvid should be an array

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
@@ -27,6 +27,7 @@ import gov.nasa.pds.harvest.meta.InternalReferenceExtractor;
 import gov.nasa.pds.harvest.meta.Metadata;
 import gov.nasa.pds.harvest.meta.XPathExtractor;
 import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
+import gov.nasa.pds.harvest.util.out.WriterManager;
 import gov.nasa.pds.harvest.util.xml.XmlDomUtils;
 
 
@@ -52,7 +53,6 @@ public class BundleProcessor
     private static final long MAX_XML_FILE_LENGTH = 10_000_000;
 
     private Configuration config;
-    private RegistryDocWriter writer;
     
     private DocumentBuilderFactory dbf;
     private BasicMetadataExtractor basicExtractor;
@@ -71,16 +71,12 @@ public class BundleProcessor
     /**
      * Constructor
      * @param config Harvest configuration parameters
-     * @param writer A writer to write JSON or XML data files with metadata
-     * extracted from PDS4 labels. Generated JSON files can be imported 
-     * into Elasticsearch by Registry manager tool. 
      * @param counter document / product counter
      * @throws Exception Generic exception
      */
-    public BundleProcessor(Configuration config, RegistryDocWriter writer, Counter counter) throws Exception
+    public BundleProcessor(Configuration config, Counter counter) throws Exception
     {
         this.config = config;
-        this.writer = writer;
         this.counter = counter;
         
         log = LogManager.getLogger(this.getClass());
@@ -191,6 +187,7 @@ public class BundleProcessor
         
         fileDataExtractor.extract(file, meta);
         
+        RegistryDocWriter writer = WriterManager.getInstance().getRegistryWriter();
         writer.write(meta);
         
         counter.prodCounters.inc(meta.prodClass);

--- a/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
@@ -174,7 +174,7 @@ public class BundleProcessor
         // Bundle already registered in the Registry (Elasticsearch)
         if(dao != null && dao.idExists(meta.lidvid))
         {
-            log.warn("Bundle " + meta.lidvid + " already registered");
+            log.warn("Bundle " + meta.lidvid + " already registered. Skipping.");
             addCollectionRefs(meta, doc);
             counter.skippedFileCount++;
             return;

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CollectionInventoryProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CollectionInventoryProcessor.java
@@ -11,6 +11,7 @@ import gov.nasa.pds.harvest.dao.RegistryDAO;
 import gov.nasa.pds.harvest.dao.RegistryManager;
 import gov.nasa.pds.harvest.meta.Metadata;
 import gov.nasa.pds.harvest.util.out.RefsDocWriter;
+import gov.nasa.pds.harvest.util.out.WriterManager;
 
 
 /**
@@ -33,19 +34,16 @@ public class CollectionInventoryProcessor
     private int ELASTIC_BATCH_SIZE = 50;
     
     private ProdRefsBatch batch = new ProdRefsBatch();
-    private RefsDocWriter writer;
     private boolean primaryOnly;
     
     
     /**
      * Constructor
-     * @param writer JSON or XML document writer.
      * @param primaryOnly if true, only process primary references
      */
-    public CollectionInventoryProcessor(RefsDocWriter writer, boolean primaryOnly)
+    public CollectionInventoryProcessor(boolean primaryOnly)
     {
         log = LogManager.getLogger(this.getClass());
-        this.writer = writer;
         this.primaryOnly = primaryOnly;
     }
     
@@ -95,6 +93,7 @@ public class CollectionInventoryProcessor
             }
             
             // Write batch
+            RefsDocWriter writer = WriterManager.getInstance().getRefsWriter();
             writer.writeBatch(meta, batch, RefType.PRIMARY);
             
             if(count < WRITE_BATCH_SIZE) break;
@@ -122,6 +121,7 @@ public class CollectionInventoryProcessor
             if(count == 0) break;
             
             // Write batch
+            RefsDocWriter writer = WriterManager.getInstance().getRefsWriter();
             writer.writeBatch(meta, batch, RefType.SECONDARY);
             
             if(count < WRITE_BATCH_SIZE) break;

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
@@ -26,8 +26,8 @@ import gov.nasa.pds.harvest.meta.FileMetadataExtractor;
 import gov.nasa.pds.harvest.meta.InternalReferenceExtractor;
 import gov.nasa.pds.harvest.meta.Metadata;
 import gov.nasa.pds.harvest.meta.XPathExtractor;
-import gov.nasa.pds.harvest.util.out.RefsDocWriter;
 import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
+import gov.nasa.pds.harvest.util.out.WriterManager;
 import gov.nasa.pds.harvest.util.xml.XmlDomUtils;
 
 
@@ -53,7 +53,6 @@ public class CollectionProcessor
     private static final long MAX_XML_FILE_LENGTH = 10_000_000;
 
     private Configuration config;
-    private RegistryDocWriter writer;
     private CollectionInventoryProcessor invProc;
     
     private DocumentBuilderFactory dbf;
@@ -71,17 +70,13 @@ public class CollectionProcessor
     /**
      * Constructor.
      * @param config Harvest configuration parameters
-     * @param writer Registry document writer (JSON or XML)
-     * @param refsWriter References document writer (JSON or XML)
      * @param counter Counter of processed products
      * @throws Exception Generic exception
      */
-    public CollectionProcessor(Configuration config, RegistryDocWriter writer, 
-            RefsDocWriter refsWriter, Counter counter) throws Exception
+    public CollectionProcessor(Configuration config, Counter counter) throws Exception
     {
         this.config = config;
-        this.writer = writer;
-        this.invProc = new CollectionInventoryProcessor(refsWriter, config.refsCfg.primaryOnly);
+        this.invProc = new CollectionInventoryProcessor(config.refsCfg.primaryOnly);
         this.counter = counter;
         
         log = LogManager.getLogger(this.getClass());
@@ -194,7 +189,9 @@ public class CollectionProcessor
             autogenExtractor.extract(file, meta.fields);
         }
         
-        fileDataExtractor.extract(file, meta);        
+        fileDataExtractor.extract(file, meta);
+        
+        RegistryDocWriter writer = WriterManager.getInstance().getRegistryWriter();
         writer.write(meta);
         
         // Cache and write product references

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
@@ -14,12 +14,7 @@ import gov.nasa.pds.harvest.meta.XPathCacheLoader;
 import gov.nasa.pds.harvest.util.CounterMap;
 import gov.nasa.pds.harvest.util.PackageIdGenerator;
 import gov.nasa.pds.harvest.util.log.LogUtils;
-import gov.nasa.pds.harvest.util.out.RefsDocWriter;
-import gov.nasa.pds.harvest.util.out.RefsDocWriterJson;
-import gov.nasa.pds.harvest.util.out.RefsDocWriterXml;
-import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
-import gov.nasa.pds.harvest.util.out.RegistryDocWriterJson;
-import gov.nasa.pds.harvest.util.out.RegistryDocWriterXml;
+import gov.nasa.pds.harvest.util.out.WriterManager;
 
 
 /**
@@ -31,8 +26,6 @@ public class CrawlerCommand
 {
     private Logger log;
     private Configuration cfg;
-    private RegistryDocWriter regWriter;
-    private RefsDocWriter refsWriter;
     
     // Processors
     private Counter counter;
@@ -71,9 +64,8 @@ public class CrawlerCommand
         {
             processBundles();
         }
-                
-        regWriter.close();
-        refsWriter.close();
+
+        WriterManager.destroy();
         RegistryManager.destroy();
         
         printSummary();
@@ -128,12 +120,10 @@ public class CrawlerCommand
         switch(outFormat)
         {
         case "xml":
-            regWriter = new RegistryDocWriterXml(fOutDir);
-            refsWriter = new RefsDocWriterXml(fOutDir);
+            WriterManager.initXml(fOutDir);
             break;
         case "json":
-            regWriter = new RegistryDocWriterJson(fOutDir);
-            refsWriter = new RefsDocWriterJson(fOutDir);
+            WriterManager.initJson(fOutDir);
             break;
         default:
             throw new Exception("Invalid output format " + outFormat);                
@@ -159,13 +149,13 @@ public class CrawlerCommand
 
         if(cfg.dirs != null)
         {
-            dirsProc = new DirsProcessor(cfg, regWriter, refsWriter, counter);
+            dirsProc = new DirsProcessor(cfg, counter);
         }
         else if(cfg.bundles != null)
         {
-            bundleProc = new BundleProcessor(cfg, regWriter, counter);
-            colProc = new CollectionProcessor(cfg, regWriter, refsWriter, counter);
-            prodProc = new ProductProcessor(cfg, regWriter, counter);
+            bundleProc = new BundleProcessor(cfg, counter);
+            colProc = new CollectionProcessor(cfg, counter);
+            prodProc = new ProductProcessor(cfg, counter);
         }
     }
 

--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -204,6 +204,7 @@ public class ProductProcessor
         LidVidCache cache = RefsCache.getInstance().getProdRefsCache();
         if(!cache.containsLidVid(meta.lidvid) && !cache.containsLid(meta.lid)) 
         {
+            log.info("Skipping product " + file.getAbsolutePath());
             counter.skippedFileCount++;
             return;
         }

--- a/src/main/java/gov/nasa/pds/harvest/util/out/NDJsonDocUtils.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/NDJsonDocUtils.java
@@ -116,7 +116,30 @@ public class NDJsonDocUtils
         }
     }
 
-    
+
+    /**
+     * Write multivalued field as an array
+     * @param jw JSON writer
+     * @param key key / field name
+     * @param values collection of values
+     * @throws Exception an exception
+     */
+    public static void writeArray(JsonWriter jw, String key, Collection<String> values) throws Exception
+    {
+        if(values == null || values.isEmpty()) return;
+
+        key = toEsFieldName(key);
+        jw.name(key);
+
+        jw.beginArray();
+        for(String value: values)
+        {
+            jw.value(value);
+        }
+        jw.endArray();
+    }
+
+        
     /**
      * Convert registry field name to the valid Elasticsearch field name. 
      * (Replace '.' with '/').

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriter.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriter.java
@@ -1,5 +1,7 @@
 package gov.nasa.pds.harvest.util.out;
 
+import java.io.Closeable;
+
 import gov.nasa.pds.harvest.crawler.ProdRefsBatch;
 import gov.nasa.pds.harvest.crawler.RefType;
 import gov.nasa.pds.harvest.meta.Metadata;
@@ -10,7 +12,7 @@ import gov.nasa.pds.harvest.meta.Metadata;
  * 
  * @author karpenko
  */
-public interface RefsDocWriter
+public interface RefsDocWriter extends Closeable
 {
     /**
      * Write a batch of product references.
@@ -20,10 +22,4 @@ public interface RefsDocWriter
      * @throws Exception Generic exception
      */
     public void writeBatch(Metadata meta, ProdRefsBatch batch, RefType refType) throws Exception;
-    
-    /**
-     * Close resources / output file.
-     * @throws Exception Generic exception
-     */
-    public void close() throws Exception;
 }

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterJson.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterJson.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.harvest.util.out;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Set;
@@ -85,7 +86,7 @@ public class RefsDocWriterJson implements RefsDocWriter
     
     
     @Override
-    public void close() throws Exception
+    public void close() throws IOException
     {
         writer.close();
     }

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterJson.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterJson.java
@@ -66,12 +66,12 @@ public class RefsDocWriterJson implements RefsDocWriter
         NDJsonDocUtils.writeField(jw, "collection_vid", meta.strVid);
         
         // Product refs
-        NDJsonDocUtils.writeField(jw, "product_lidvid", batch.lidvids);
+        NDJsonDocUtils.writeArray(jw, "product_lidvid", batch.lidvids);
         
         // Convert lidvids to lids
         Set<String> lids = LidVidUtils.lidvidToLid(batch.lidvids);
         lids = LidVidUtils.add(lids, batch.lids);
-        NDJsonDocUtils.writeField(jw, "product_lid", lids);
+        NDJsonDocUtils.writeArray(jw, "product_lid", lids);
         
         // Transaction ID
         NDJsonDocUtils.writeField(jw, "_package_id", PackageIdGenerator.getInstance().getPackageId());

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterJson.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterJson.java
@@ -63,7 +63,7 @@ public class RefsDocWriterJson implements RefsDocWriter
         // Collection ids
         NDJsonDocUtils.writeField(jw, "collection_lidvid", meta.lidvid);
         NDJsonDocUtils.writeField(jw, "collection_lid", meta.lid);
-        NDJsonDocUtils.writeField(jw, "collection_vid", meta.vid);
+        NDJsonDocUtils.writeField(jw, "collection_vid", meta.strVid);
         
         // Product refs
         NDJsonDocUtils.writeField(jw, "product_lidvid", batch.lidvids);

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterXml.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterXml.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.harvest.util.out;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
 import java.util.Set;
 
@@ -32,7 +33,7 @@ public class RefsDocWriterXml implements RefsDocWriter
     {
         super();
         
-        File file = new File(outDir, "refs-docs.xml");        
+        File file = new File(outDir, "refs-docs.xml");
         writer = new FileWriter(file);
         
         writer.append("<add>\n");
@@ -77,7 +78,7 @@ public class RefsDocWriterXml implements RefsDocWriter
 
 
     @Override
-    public void close() throws Exception
+    public void close() throws IOException
     {
         writer.append("</add>\n");
         writer.close();

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterXml.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RefsDocWriterXml.java
@@ -59,7 +59,7 @@ public class RefsDocWriterXml implements RefsDocWriter
         // Collection ids
         XmlDocUtils.writeField(writer, "collection_lidvid", meta.lidvid);
         XmlDocUtils.writeField(writer, "collection_lid", meta.lid);
-        XmlDocUtils.writeField(writer, "collection_vid", meta.vid);
+        XmlDocUtils.writeField(writer, "collection_vid", meta.strVid);
         
         // Product refs
         XmlDocUtils.writeField(writer, "product_lidvid", batch.lidvids);

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriter.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriter.java
@@ -1,5 +1,7 @@
 package gov.nasa.pds.harvest.util.out;
 
+import java.io.Closeable;
+
 import gov.nasa.pds.harvest.meta.Metadata;
 
 
@@ -8,7 +10,7 @@ import gov.nasa.pds.harvest.meta.Metadata;
  *  
  * @author karpenko
  */
-public interface RegistryDocWriter
+public interface RegistryDocWriter extends Closeable
 {
     /**
      * Write metadata extracted from PDS4 labels.
@@ -16,10 +18,4 @@ public interface RegistryDocWriter
      * @throws Exception Generic exception
      */
     public void write(Metadata meta) throws Exception;
-    
-    /**
-     * Close resources / output file.
-     * @throws Exception Generic exception
-     */
-    public void close() throws Exception;
 }

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterJson.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterJson.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.harvest.util.out;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Set;
@@ -112,7 +113,7 @@ public class RegistryDocWriterJson implements RegistryDocWriter
     
     
     @Override
-    public void close() throws Exception
+    public void close() throws IOException
     {
         writer.close();
 
@@ -123,7 +124,7 @@ public class RegistryDocWriterJson implements RegistryDocWriter
     }
     
     
-    private void saveFields() throws Exception
+    private void saveFields() throws IOException
     {
         File file = new File(outDir, "fields.txt");
         FileWriter wr = new FileWriter(file);

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterJson.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterJson.java
@@ -66,7 +66,7 @@ public class RegistryDocWriterJson implements RegistryDocWriter
 
         // Basic info
         NDJsonDocUtils.writeField(jw, "lid", meta.lid);
-        NDJsonDocUtils.writeField(jw, "vid", meta.vid);
+        NDJsonDocUtils.writeField(jw, "vid", meta.strVid);
         NDJsonDocUtils.writeField(jw, "lidvid", lidvid);
         NDJsonDocUtils.writeField(jw, "title", meta.title);
         NDJsonDocUtils.writeField(jw, "product_class", meta.prodClass);

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterXml.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterXml.java
@@ -102,7 +102,7 @@ public class RegistryDocWriterXml implements RegistryDocWriter
         // Basic info
         String lidvid = meta.lid + "::" + meta.vid;
         XmlDocUtils.writeField(writer, "lid", meta.lid);
-        XmlDocUtils.writeField(writer, "vid", meta.vid);
+        XmlDocUtils.writeField(writer, "vid", meta.strVid);
         XmlDocUtils.writeField(writer, "lidvid", lidvid);
         XmlDocUtils.writeField(writer, "title", meta.title);
         XmlDocUtils.writeField(writer, "product_class", meta.prodClass);

--- a/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterXml.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/RegistryDocWriterXml.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.harvest.util.out;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
 import java.util.Collection;
 import java.util.Set;
@@ -51,7 +52,7 @@ public class RegistryDocWriterXml implements RegistryDocWriter
 
     
     @Override
-    public void close() throws Exception
+    public void close() throws IOException
     {
         writer.append("</add>\n");
         writer.close();
@@ -63,7 +64,7 @@ public class RegistryDocWriterXml implements RegistryDocWriter
     }
 
     
-    private void saveFields() throws Exception
+    private void saveFields() throws IOException
     {
         File file = new File(outDir, "fields.txt");
         FileWriter wr = new FileWriter(file);

--- a/src/main/java/gov/nasa/pds/harvest/util/out/SupplementalWriter.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/SupplementalWriter.java
@@ -1,0 +1,50 @@
+package gov.nasa.pds.harvest.util.out;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+import gov.nasa.pds.harvest.util.CloseUtils;
+
+/**
+ * Write a list of file paths of supplemental product labels.
+ * 
+ * @author karpenko
+ */
+public class SupplementalWriter implements Closeable
+{
+    private Writer writer;
+    
+    
+    /**
+     * Constructor
+     * @param outDir output directory
+     * @throws Exception an exception
+     */
+    public SupplementalWriter(File outDir) throws Exception
+    {
+        File file = new File(outDir, "supplemental.txt");
+        writer = new FileWriter(file);
+    }
+
+    
+    @Override
+    public void close() throws IOException
+    {
+        CloseUtils.close(writer);
+    }
+    
+    
+    /**
+     * Write supplemental product label file path
+     * @param file supplemental product label file
+     * @throws IOException an exception
+     */
+    public void write(File file) throws IOException
+    {
+        writer.write(file.getAbsolutePath());
+        writer.write("\n");
+    }
+}

--- a/src/main/java/gov/nasa/pds/harvest/util/out/WriterManager.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/out/WriterManager.java
@@ -1,0 +1,117 @@
+package gov.nasa.pds.harvest.util.out;
+
+import java.io.File;
+
+import gov.nasa.pds.harvest.util.CloseUtils;
+
+
+/**
+ * Singleton to hold references to registry metadata, collection inventory (product references)
+ * and other data writers.
+ * 
+ * @author karpenko
+ */
+public class WriterManager
+{
+    private static WriterManager instance;
+    
+    private RegistryDocWriter regWriter;
+    private RefsDocWriter refsWriter;
+    private SupplementalWriter supWriter;
+
+   
+    /**
+     * Provate constructor. Use getInstance() instead.
+     */
+    private WriterManager(File outDir) throws Exception
+    {
+        supWriter = new SupplementalWriter(outDir);
+    }
+
+    
+    /**
+     * Create writers to write JSON data files with metadata
+     * extracted from PDS4 labels. Generated JSON files can be imported 
+     * into Elasticsearch by Registry manager tool. 
+     * @param outDir output directory
+     * @throws Exception an exception
+     */
+    public static void initJson(File outDir) throws Exception
+    {
+        if(instance != null) throw new Exception("WriterManager is already initialized.");
+        
+        instance = new WriterManager(outDir);
+        instance.regWriter = new RegistryDocWriterJson(outDir);
+        instance.refsWriter = new RefsDocWriterJson(outDir);
+    }
+
+    
+    /**
+     * Create writers to write XML data files with metadata
+     * extracted from PDS4 labels. 
+     * @param outDir output directory
+     * @throws Exception an exception
+     */
+    public static void initXml(File outDir) throws Exception
+    {
+        instance = new WriterManager(outDir);
+        instance.regWriter = new RegistryDocWriterXml(outDir);
+        instance.refsWriter = new RefsDocWriterXml(outDir);
+    }
+
+    
+    /**
+     * Clean up resources / close files.
+     */
+    public static void destroy()
+    {
+        if(instance == null) return;
+        
+        CloseUtils.close(instance.regWriter);
+        CloseUtils.close(instance.refsWriter);
+        CloseUtils.close(instance.supWriter);
+    }
+
+    
+    /**
+     * Get singleton instance.
+     * @return the singleton instance.
+     * @throws Exception an exception.
+     */
+    public static WriterManager getInstance() throws Exception
+    {
+        if(instance == null) throw new Exception("WriterManager is not initialized.");
+        
+        return instance;
+    }
+    
+    
+    /**
+     * Get registry metadata writer.
+     * @return registry metadata writer
+     */
+    public RegistryDocWriter getRegistryWriter()
+    {
+        return regWriter;
+    }
+
+    
+    /**
+     * Get collection inventory (product references) writer
+     * @return collection inventory (product references) writer
+     */
+    public RefsDocWriter getRefsWriter()
+    {
+        return refsWriter;
+    }
+
+    
+    /**
+     * Get a writer for supplemental products
+     * @return a writer for supplemental products
+     */
+    public SupplementalWriter getSupplementalWriter()
+    {
+        return supWriter;
+    }
+}


### PR DESCRIPTION
**(1) Bug-130**
See https://github.com/NASA-PDS/pds-registry-app/issues/130 for details

**Test Instructions**
- Configure Harvest to run in "bundle" mode. Make sure `<registry>` parameter is pointing to running Elasticsearch.
- Harvest a collection (within a bundle) and load data into registry with Registry Manager.
- Add a product to the collection (don't forget to update inventory file). Increment the collection VID. Re-harvest.
- Only new product (and collection), but not all products from the collection should show up in `registry-docs.json`

**(2) Bug-50**
See https://github.com/NASA-PDS/harvest/issues/50

**Test Instructions**
See https://github.com/NASA-PDS/harvest/issues/50
