### PR TITLE
Search fields (description), label BLOB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
         </dependency>
+        <!-- XML to JSON converter -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20210307</version>
+        </dependency>
         <!-- Registry Common library-->
         <dependency>
             <groupId>gov.nasa.pds</groupId>

--- a/src/main/java/gov/nasa/pds/harvest/Constants.java
+++ b/src/main/java/gov/nasa/pds/harvest/Constants.java
@@ -13,4 +13,5 @@ public interface Constants
     public static final String REGISTRY_NS = "ops";
     
     public static final String FLD_NODE_NAME = "ops:Harvest_Info/ops:node_name";
+    public static final String FLD_HARVEST_DATA_TIME = "ops:Harvest_Info/ops:harvest_date_time";
 }

--- a/src/main/java/gov/nasa/pds/harvest/cfg/model/FileInfoCfg.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/model/FileInfoCfg.java
@@ -19,9 +19,9 @@ public class FileInfoCfg
     public List<FileRefCfg> fileRef;
     
     public boolean processDataFiles = true;
-    public boolean storeLabels = false;    
+    public boolean storeLabels = true;
 
-    
+
     public FileInfoCfg()
     {
     }

--- a/src/main/java/gov/nasa/pds/harvest/cfg/model/FileInfoCfg.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/model/FileInfoCfg.java
@@ -20,6 +20,7 @@ public class FileInfoCfg
     
     public boolean processDataFiles = true;
     public boolean storeLabels = true;
+    public boolean storeJsonLabels = true;
 
 
     public FileInfoCfg()

--- a/src/main/java/gov/nasa/pds/harvest/cfg/parser/ConfigParserUtils.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/parser/ConfigParserUtils.java
@@ -1,0 +1,25 @@
+package gov.nasa.pds.harvest.cfg.parser;
+
+/**
+ * Utility methods for parsing Harvest configuration file.
+ * @author karpenko
+ */
+public class ConfigParserUtils
+{
+    /**
+     * Parse boolean string. The following case insensitive values are supported:
+     * "yes", "true", "no", "false".
+     * @param str A string to parse
+     * @return true if the string = "yes" or "true"; false if the string = "no" or "false";
+     * null if the string has another value.
+     */
+    public static Boolean parseBoolean(String str)
+    {
+        if(str == null) return null;
+        
+        if(str.equalsIgnoreCase("true") || str.equalsIgnoreCase("yes")) return true;
+        if(str.equalsIgnoreCase("false") || str.equalsIgnoreCase("no")) return false;
+        
+        return null;
+    }
+}

--- a/src/main/java/gov/nasa/pds/harvest/cfg/parser/FileInfoParser.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/parser/FileInfoParser.java
@@ -22,11 +22,15 @@ import gov.nasa.pds.harvest.util.xml.XmlDomUtils;
  */
 public class FileInfoParser
 {
+    /**
+     * Valid &lt;FileInfo&gt; attribute names.
+     */
     private static Set<String> FILE_INFO_ATTRS = new TreeSet<>();
     static
     {
         FILE_INFO_ATTRS.add("processDataFiles");
         FILE_INFO_ATTRS.add("storeLabels");
+        FILE_INFO_ATTRS.add("storeJsonLabels");
     }
 
     
@@ -81,6 +85,23 @@ public class FileInfoParser
             }
 
             fileInfo.storeLabels = bb;
+        }
+
+        // "storeJsonLabels" attribute
+        str = XmlDomUtils.getAttribute(node, "storeJsonLabels");
+        if(str == null)
+        {
+            fileInfo.storeJsonLabels = true;
+        }
+        else
+        {
+            Boolean bb = ConfigParserUtils.parseBoolean(str);
+            if(bb == null)
+            {
+                throw new Exception("Invalid <fileInfo storeJsonLabels=\"" + str + "\" attribute.");
+            }
+
+            fileInfo.storeJsonLabels = bb;
         }
         
         // <fileRef> nodes

--- a/src/main/java/gov/nasa/pds/harvest/cfg/parser/FileInfoParser.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/parser/FileInfoParser.java
@@ -30,25 +30,58 @@ public class FileInfoParser
     }
 
     
+    /**
+     * Parse &lt;fileInfo&gt; section of Harvest configuration file
+     * @param doc Parsed Harvest configuration file (XMl DOM)
+     * @return File info model object
+     * @throws Exception an exception
+     */
     public static FileInfoCfg parseFileInfo(Document doc) throws Exception
     {
         XPathUtils xpu = new XPathUtils();
+        FileInfoCfg fileInfo = new FileInfoCfg();
         
         int count = xpu.getNodeCount(doc, "/harvest/fileInfo");
-        if(count == 0) return null;
+        if(count == 0) return fileInfo;
         if(count > 1) throw new Exception("Could not have more than one '/harvest/fileInfo' element.");
-
-        FileInfoCfg fileInfo = new FileInfoCfg();
 
         // <fileInfo> node
         Node node = xpu.getFirstNode(doc, "/harvest/fileInfo");
         validateAttributes(node, FILE_INFO_ATTRS);
         
+        // "processDataFiles" attribute
         String str = XmlDomUtils.getAttribute(node, "processDataFiles");
-        fileInfo.processDataFiles = (str == null || "true".equalsIgnoreCase(str) || "yes".equalsIgnoreCase(str));
+        if(str == null)
+        {
+            fileInfo.processDataFiles = true;
+        }
+        else
+        {
+            Boolean bb = ConfigParserUtils.parseBoolean(str);
+            if(bb == null)
+            {
+                throw new Exception("Invalid <fileInfo processDataFiles=\"" + str + "\" attribute.");
+            }
+            
+            fileInfo.processDataFiles = bb;
+        }
         
+        // "storeLabels" attribute
         str = XmlDomUtils.getAttribute(node, "storeLabels");
-        fileInfo.storeLabels = ("true".equalsIgnoreCase(str) || "yes".equalsIgnoreCase(str));        
+        if(str == null)
+        {
+            fileInfo.storeLabels = true;
+        }
+        else
+        {
+            Boolean bb = ConfigParserUtils.parseBoolean(str);
+            if(bb == null)
+            {
+                throw new Exception("Invalid <fileInfo storeLabels=\"" + str + "\" attribute.");
+            }
+
+            fileInfo.storeLabels = bb;
+        }
         
         // <fileRef> nodes
         fileInfo.fileRef = parseFileRef(doc);

--- a/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
-import gov.nasa.pds.harvest.Constants;
 import gov.nasa.pds.harvest.cfg.model.BundleCfg;
 import gov.nasa.pds.harvest.cfg.model.Configuration;
 import gov.nasa.pds.harvest.dao.RegistryManager;
@@ -84,7 +83,7 @@ public class BundleProcessor
         dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(false);
         
-        basicExtractor = new BasicMetadataExtractor();
+        basicExtractor = new BasicMetadataExtractor(config);
         bundleExtractor = new BundleMetadataExtractor();
         refExtractor = new InternalReferenceExtractor();
         xpathExtractor = new XPathExtractor();
@@ -157,7 +156,6 @@ public class BundleProcessor
     private void processMetadata(File file, Document doc) throws Exception
     {
         Metadata meta = basicExtractor.extract(file, doc);
-        meta.fields.addValue(Constants.FLD_NODE_NAME, config.nodeName);
         
         if(bundleCfg.versions != null && !bundleCfg.versions.contains(meta.strVid)) return;
 

--- a/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
@@ -24,6 +24,7 @@ import gov.nasa.pds.harvest.meta.BundleMetadataExtractor;
 import gov.nasa.pds.harvest.meta.FileMetadataExtractor;
 import gov.nasa.pds.harvest.meta.InternalReferenceExtractor;
 import gov.nasa.pds.harvest.meta.Metadata;
+import gov.nasa.pds.harvest.meta.SearchMetadataExtractor;
 import gov.nasa.pds.harvest.meta.XPathExtractor;
 import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
 import gov.nasa.pds.harvest.util.out.WriterManager;
@@ -58,6 +59,7 @@ public class BundleProcessor
     private BundleMetadataExtractor bundleExtractor;
     private InternalReferenceExtractor refExtractor;
     private AutogenExtractor autogenExtractor;
+    private SearchMetadataExtractor searchExtractor;
     private XPathExtractor xpathExtractor;
     private FileMetadataExtractor fileDataExtractor;
     
@@ -88,6 +90,7 @@ public class BundleProcessor
         refExtractor = new InternalReferenceExtractor();
         xpathExtractor = new XPathExtractor();
         autogenExtractor = new AutogenExtractor(config.autogen);
+        searchExtractor = new SearchMetadataExtractor();
         fileDataExtractor = new FileMetadataExtractor(config);
     }
     
@@ -174,15 +177,25 @@ public class BundleProcessor
             return;
         }
         
+        // Internal references
         refExtractor.addRefs(meta.intRefs, doc);
+        
+        // Collection references
         addCollectionRefs(meta, doc);
+        
+        // Extract fields by XPaths (if configured)
         xpathExtractor.extract(doc, meta.fields);
         
+        // All fields as key-value pairs
         if(config.autogen != null)
         {
             autogenExtractor.extract(file, meta.fields);
         }
         
+        // Search fields
+        searchExtractor.extract(doc, meta.fields);
+        
+        // File information (name, size, checksum)
         fileDataExtractor.extract(file, meta);
         
         RegistryDocWriter writer = WriterManager.getInstance().getRegistryWriter();

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
-import gov.nasa.pds.harvest.Constants;
 import gov.nasa.pds.harvest.cfg.model.BundleCfg;
 import gov.nasa.pds.harvest.cfg.model.Configuration;
 import gov.nasa.pds.harvest.dao.RegistryDAO;
@@ -84,7 +83,7 @@ public class CollectionProcessor
         dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(false);
         
-        basicExtractor = new BasicMetadataExtractor();
+        basicExtractor = new BasicMetadataExtractor(config);
         collectionExtractor = new CollectionMetadataExtractor();
         refExtractor = new InternalReferenceExtractor();
         xpathExtractor = new XPathExtractor();
@@ -153,7 +152,6 @@ public class CollectionProcessor
     private void processMetadata(File file, Document doc, BundleCfg bCfg) throws Exception
     {
         Metadata meta = basicExtractor.extract(file, doc);
-        meta.fields.addValue(Constants.FLD_NODE_NAME, config.nodeName);
 
         // Collection filter
         if(bCfg.collectionLids != null && !bCfg.collectionLids.contains(meta.lid)) return;

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
@@ -24,6 +24,7 @@ import gov.nasa.pds.harvest.meta.CollectionMetadataExtractor;
 import gov.nasa.pds.harvest.meta.FileMetadataExtractor;
 import gov.nasa.pds.harvest.meta.InternalReferenceExtractor;
 import gov.nasa.pds.harvest.meta.Metadata;
+import gov.nasa.pds.harvest.meta.SearchMetadataExtractor;
 import gov.nasa.pds.harvest.meta.XPathExtractor;
 import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
 import gov.nasa.pds.harvest.util.out.WriterManager;
@@ -59,6 +60,7 @@ public class CollectionProcessor
     private CollectionMetadataExtractor collectionExtractor;
     private InternalReferenceExtractor refExtractor;
     private AutogenExtractor autogenExtractor;
+    private SearchMetadataExtractor searchExtractor;
     private XPathExtractor xpathExtractor;
     private FileMetadataExtractor fileDataExtractor;
     
@@ -88,6 +90,7 @@ public class CollectionProcessor
         refExtractor = new InternalReferenceExtractor();
         xpathExtractor = new XPathExtractor();
         autogenExtractor = new AutogenExtractor(config.autogen);
+        searchExtractor = new SearchMetadataExtractor();
         fileDataExtractor = new FileMetadataExtractor(config);
     }
     
@@ -179,14 +182,22 @@ public class CollectionProcessor
             return;
         }
         
+        // Internal references
         refExtractor.addRefs(meta.intRefs, doc);
+        
+        // Extract fields by XPath (if configured)
         xpathExtractor.extract(doc, meta.fields);
         
+        // Extract all fields as key-value pairs
         if(config.autogen != null)
         {
             autogenExtractor.extract(file, meta.fields);
         }
         
+        // Search fields
+        searchExtractor.extract(doc, meta.fields);
+
+        // File information (name, size, checksum)
         fileDataExtractor.extract(file, meta);
         
         RegistryDocWriter writer = WriterManager.getInstance().getRegistryWriter();

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CrawlerCommand.java
@@ -135,9 +135,10 @@ public class CrawlerCommand
         ConfigReader cfgReader = new ConfigReader();
         cfg = cfgReader.read(cfgFile);
 
-        if(cfg.registryCfg == null)
+        if(cfg.bundles != null && cfg.registryCfg == null)
         {
-            log.warn("Registry is not configured");
+            log.warn("Registry (Elasticsearch) is not configured. "
+                    + "Registered products will be processed again.");
         }
 
         // Xpath maps

--- a/src/main/java/gov/nasa/pds/harvest/crawler/DirsProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/DirsProcessor.java
@@ -23,6 +23,7 @@ import gov.nasa.pds.harvest.meta.CollectionMetadataExtractor;
 import gov.nasa.pds.harvest.meta.FileMetadataExtractor;
 import gov.nasa.pds.harvest.meta.InternalReferenceExtractor;
 import gov.nasa.pds.harvest.meta.Metadata;
+import gov.nasa.pds.harvest.meta.SearchMetadataExtractor;
 import gov.nasa.pds.harvest.meta.XPathExtractor;
 import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
 import gov.nasa.pds.harvest.util.out.SupplementalWriter;
@@ -63,6 +64,7 @@ public class DirsProcessor
     private BasicMetadataExtractor basicExtractor;
     private InternalReferenceExtractor refExtractor;
     private AutogenExtractor autogenExtractor;
+    private SearchMetadataExtractor searchExtractor;
     private XPathExtractor xpathExtractor;
     private FileMetadataExtractor fileDataExtractor;
     
@@ -89,6 +91,7 @@ public class DirsProcessor
         basicExtractor = new BasicMetadataExtractor(config);
         refExtractor = new InternalReferenceExtractor();
         autogenExtractor = new AutogenExtractor(config.autogen);
+        searchExtractor = new SearchMetadataExtractor();
         fileDataExtractor = new FileMetadataExtractor(config);
         xpathExtractor = new XPathExtractor();
         
@@ -202,6 +205,9 @@ public class DirsProcessor
         {
             autogenExtractor.extract(file, meta.fields);
         }
+        
+        // Extract search fields
+        searchExtractor.extract(doc, meta.fields);
 
         // Extract file data
         fileDataExtractor.extract(file, meta);

--- a/src/main/java/gov/nasa/pds/harvest/crawler/DirsProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/DirsProcessor.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
-import gov.nasa.pds.harvest.Constants;
 import gov.nasa.pds.harvest.cfg.model.Configuration;
 import gov.nasa.pds.harvest.meta.AutogenExtractor;
 import gov.nasa.pds.harvest.meta.BasicMetadataExtractor;
@@ -87,7 +86,7 @@ public class DirsProcessor
         dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(false);
         
-        basicExtractor = new BasicMetadataExtractor();
+        basicExtractor = new BasicMetadataExtractor(config);
         refExtractor = new InternalReferenceExtractor();
         autogenExtractor = new AutogenExtractor(config.autogen);
         fileDataExtractor = new FileMetadataExtractor(config);
@@ -170,7 +169,6 @@ public class DirsProcessor
     {
         // Extract basic metadata
         Metadata meta = basicExtractor.extract(file, doc);
-        meta.fields.addValue(Constants.FLD_NODE_NAME, config.nodeName);
 
         log.info("Processing " + file.getAbsolutePath());
 

--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 
-import gov.nasa.pds.harvest.Constants;
 import gov.nasa.pds.harvest.cfg.model.BundleCfg;
 import gov.nasa.pds.harvest.cfg.model.Configuration;
 import gov.nasa.pds.harvest.meta.AutogenExtractor;
@@ -76,7 +75,7 @@ public class ProductProcessor
         dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(false);
         
-        basicExtractor = new BasicMetadataExtractor();
+        basicExtractor = new BasicMetadataExtractor(config);
         refExtractor = new InternalReferenceExtractor();
         autogenExtractor = new AutogenExtractor(config.autogen);
         fileDataExtractor = new FileMetadataExtractor(config);
@@ -195,7 +194,6 @@ public class ProductProcessor
     {
         // Extract basic metadata
         Metadata meta = basicExtractor.extract(file, doc);
-        meta.fields.addValue(Constants.FLD_NODE_NAME, config.nodeName);
 
         // Only process primary products from collection inventory
         LidVidCache cache = RefsCache.getInstance().getProdRefsCache();

--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -21,6 +21,7 @@ import gov.nasa.pds.harvest.meta.BasicMetadataExtractor;
 import gov.nasa.pds.harvest.meta.FileMetadataExtractor;
 import gov.nasa.pds.harvest.meta.InternalReferenceExtractor;
 import gov.nasa.pds.harvest.meta.Metadata;
+import gov.nasa.pds.harvest.meta.SearchMetadataExtractor;
 import gov.nasa.pds.harvest.meta.XPathExtractor;
 import gov.nasa.pds.harvest.util.out.RegistryDocWriter;
 import gov.nasa.pds.harvest.util.out.SupplementalWriter;
@@ -55,6 +56,7 @@ public class ProductProcessor
     private BasicMetadataExtractor basicExtractor;
     private InternalReferenceExtractor refExtractor;
     private AutogenExtractor autogenExtractor;
+    private SearchMetadataExtractor searchExtractor;
     private FileMetadataExtractor fileDataExtractor;
     private XPathExtractor xpathExtractor;
     
@@ -78,6 +80,7 @@ public class ProductProcessor
         basicExtractor = new BasicMetadataExtractor(config);
         refExtractor = new InternalReferenceExtractor();
         autogenExtractor = new AutogenExtractor(config.autogen);
+        searchExtractor = new SearchMetadataExtractor();
         fileDataExtractor = new FileMetadataExtractor(config);
         xpathExtractor = new XPathExtractor();
         
@@ -218,6 +221,9 @@ public class ProductProcessor
             autogenExtractor.extract(file, meta.fields);
         }
 
+        // Search fields
+        searchExtractor.extract(doc, meta.fields);
+        
         // Extract file data
         fileDataExtractor.extract(file, meta);
         

--- a/src/main/java/gov/nasa/pds/harvest/meta/AutogenExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/AutogenExtractor.java
@@ -20,6 +20,10 @@ import gov.nasa.pds.harvest.util.xml.XmlDomUtils;
 import gov.nasa.pds.registry.common.util.date.PdsDateConverter;
 
 
+/**
+ * Generates key-value pairs for all fields in a PDS label.
+ * @author karpenko
+ */
 public class AutogenExtractor
 {
     private AutogenCfg cfg;
@@ -29,7 +33,11 @@ public class AutogenExtractor
     private FieldMap fields;
     private PdsDateConverter dateConverter;
     
-    
+   
+    /**
+     * Constructor
+     * @param cfg Configuration
+     */
     public AutogenExtractor(AutogenCfg cfg)
     {
         this.cfg = cfg;
@@ -39,7 +47,13 @@ public class AutogenExtractor
         globalNsMap.put("http://pds.nasa.gov/pds4/pds/v1", "pds");
     }
 
-    
+
+    /**
+     * Extracts all fields from a label file into a FieldMap
+     * @param file PDS label file
+     * @param fields key-value pairs (output parameter)
+     * @throws Exception an exception
+     */
     public void extract(File file, FieldMap fields) throws Exception
     {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -49,6 +63,12 @@ public class AutogenExtractor
     }
     
     
+    /**
+     * Extracts all fields from a parsed label file (XML DOM) into a FieldMap
+     * @param doc Parsed PDS label file (XML DOM)
+     * @param fields key-value pairs (output parameter)
+     * @throws Exception an exception
+     */
     public void extract(Document doc, FieldMap fields) throws Exception
     {
         this.localNsMap = getDocNamespaces(doc);

--- a/src/main/java/gov/nasa/pds/harvest/meta/BasicMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/BasicMetadataExtractor.java
@@ -16,6 +16,10 @@ import gov.nasa.pds.harvest.util.PdsStringUtils;
 import gov.nasa.pds.harvest.util.xml.XPathUtils;
 
 
+/**
+ * Extract basic metadata, such as LID, VID, title from a PDS label.
+ * @author karpenko
+ */
 public class BasicMetadataExtractor
 {
     private XPathExpression xLid;
@@ -26,6 +30,10 @@ public class BasicMetadataExtractor
     private XPathExpression xDocFile;
     
 
+    /**
+     * Constructor
+     * @throws Exception
+     */
     public BasicMetadataExtractor() throws Exception
     {
         XPathFactory xpf = XPathFactory.newInstance();
@@ -38,7 +46,14 @@ public class BasicMetadataExtractor
         xDocFile = XPathUtils.compileXPath(xpf, "//Document_File");
     }
 
-    
+
+    /**
+     * Extract basic metadata from a PDS label
+     * @param file PDS label file
+     * @param doc Parsed PDS label file (XML DOM)
+     * @return extracted metadata
+     * @throws Exception an exception
+     */
     public Metadata extract(File file, Document doc) throws Exception
     {
         Metadata md = new Metadata();        

--- a/src/main/java/gov/nasa/pds/harvest/meta/BundleMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/BundleMetadataExtractor.java
@@ -14,8 +14,16 @@ import gov.nasa.pds.harvest.util.FieldMap;
 import gov.nasa.pds.harvest.util.xml.XPathUtils;
 
 
+/**
+ * Extract metadata from a PDS bundle
+ * @author karpenko
+ */
 public class BundleMetadataExtractor
 {
+    /**
+     * Inner class to store bundle member (collection) information.
+     * @author karpenko
+     */
     public static class BundleMemberEntry
     {
         public String lid;
@@ -40,7 +48,11 @@ public class BundleMetadataExtractor
     
     private XPathExpression xBme;
     
-    
+
+    /**
+     * Constructor
+     * @throws Exception an exception
+     */
     public BundleMetadataExtractor() throws Exception
     {
         XPathFactory xpf = XPathFactory.newInstance();
@@ -48,6 +60,12 @@ public class BundleMetadataExtractor
     }
     
     
+    /**
+     * Extract bundle members (collections)
+     * @param doc Parsed PDS label (XML DOM)
+     * @return list of bundle members (collections)
+     * @throws Exception an exception
+     */
     public List<BundleMemberEntry> extractBundleMemberEntries(Document doc) throws Exception
     {
         List<BundleMemberEntry> list = new ArrayList<BundleMemberEntry>();
@@ -64,7 +82,12 @@ public class BundleMetadataExtractor
         return list;
     }
 
-    
+
+    /**
+     * Add a collection reference (LID and LIDVID) from bundle member entry to the field map.
+     * @param fmap keeps list of collection references
+     * @param bme bundle member entry
+     */
     public void addRefs(FieldMap fmap, BundleMemberEntry bme)
     {
         if(bme.lidvid != null)

--- a/src/main/java/gov/nasa/pds/harvest/meta/CollectionMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/CollectionMetadataExtractor.java
@@ -10,11 +10,19 @@ import org.w3c.dom.Document;
 import gov.nasa.pds.harvest.util.xml.XPathUtils;
 
 
+/**
+ * Extracts collection metadata
+ * @author karpenko
+ */
 public class CollectionMetadataExtractor
 {
     private XPathExpression xFileName;
     
-    
+
+    /**
+     * Constructor
+     * @throws Exception
+     */
     public CollectionMetadataExtractor() throws Exception
     {
         XPathFactory xpf = XPathFactory.newInstance();
@@ -22,6 +30,12 @@ public class CollectionMetadataExtractor
     }
     
 
+    /**
+     * Extract collection inventory file names
+     * @param doc Parsed collection label (XML DOM)
+     * @return a set of files (usually there is only one inventory file)
+     * @throws Exception an exception
+     */
     public Set<String> extractInventoryFileNames(Document doc) throws Exception
     {
         return XPathUtils.getStringSet(doc, xFileName);

--- a/src/main/java/gov/nasa/pds/harvest/meta/FileMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/FileMetadataExtractor.java
@@ -3,7 +3,10 @@ package gov.nasa.pds.harvest.meta;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
@@ -15,6 +18,8 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tika.Tika;
+import org.json.JSONObject;
+import org.json.XML;
 
 import gov.nasa.pds.harvest.cfg.model.FileInfoCfg;
 import gov.nasa.pds.harvest.Constants;
@@ -53,7 +58,15 @@ public class FileMetadataExtractor
 
         if(fileInfoCfg.storeLabels == false)
         {
-            log.warn("BLOB storage is disabled (see <fileInfo storeLabels=\"false\"> configuration). "
+            log.warn("XML BLOB storage is disabled "
+                    + "(see <fileInfo storeLabels=\"false\"> configuration). "
+                    + "Not all Registry features will be available.");
+        }
+
+        if(fileInfoCfg.storeJsonLabels == false)
+        {
+            log.warn("JSON BLOB storage is disabled "
+                    + "(see <fileInfo storeJsonLabels=\"false\"> configuration). "
                     + "Not all Registry features will be available.");
         }
         
@@ -80,9 +93,16 @@ public class FileMetadataExtractor
         meta.fields.addValue(createLabelFileFieldName("md5_checksum"), getMd5(file));
         meta.fields.addValue(createLabelFileFieldName("file_ref"), getFileRef(file));
         
+        // XML BLOB (optional)
         if(fileInfoCfg.storeLabels)
         {
             meta.fields.addValue(createLabelFileFieldName("blob"), getBlob(file));
+        }
+        
+        // JSON BLOB (required)
+        if(fileInfoCfg.storeJsonLabels)
+        {
+            meta.fields.addValue(createLabelFileFieldName("json_blob"), getJsonBlob(file));
         }
         
         // Process data files
@@ -130,7 +150,13 @@ public class FileMetadataExtractor
     }
     
     
-    private String getMd5(File file) throws Exception
+    /**
+     * Calculate MD5 hash of a file
+     * @param file a file
+     * @return HEX encoded MD5 hash
+     * @throws Exception an exception
+     */
+    public String getMd5(File file) throws Exception
     {
         md5Digest.reset();
         FileInputStream source = null;
@@ -155,11 +181,19 @@ public class FileMetadataExtractor
     }
     
     
-    private String getBlob(File file) throws Exception
+    /**
+     * Deflate (zip) PDS XML label and then Base64 encode.
+     * @param file PDS XML label
+     * @return Base64 encoded string
+     * @throws Exception an exception
+     */
+    public String getBlob(File file) throws Exception
     {
         FileInputStream source = null;
         
+        // Zipped content holder
         ByteArrayOutputStream bas = new ByteArrayOutputStream();
+        // Zipper
         DeflaterOutputStream dest = new DeflaterOutputStream(bas);
         
         try
@@ -182,6 +216,40 @@ public class FileMetadataExtractor
     }
 
 
+    /**
+     * Convert PDS XML label into JSON, deflate (zip) and then Base64 encode.
+     * @param file PDS XML label
+     * @return Base64 encoded string
+     * @throws Exception an exception
+     */
+    public static String getJsonBlob(File file) throws Exception
+    {
+        Reader source = null;
+        
+        // Zipped content holder
+        ByteArrayOutputStream bas = new ByteArrayOutputStream();
+        // Zipper
+        DeflaterOutputStream deflater = new DeflaterOutputStream(bas);
+        // Writer to output stream adapter
+        OutputStreamWriter dest = new OutputStreamWriter(deflater);
+        
+        try
+        {
+            source = new FileReader(file);
+            JSONObject json = XML.toJSONObject(source);
+            String strJson = json.toString();
+            dest.write(strJson);
+            dest.close();
+
+            return Base64.getEncoder().encodeToString(bas.toByteArray());
+        }
+        finally
+        {
+            CloseUtils.close(source);
+        }
+    }
+
+    
     private String getFileRef(File file)
     {
         String filePath = file.toURI().getPath();

--- a/src/main/java/gov/nasa/pds/harvest/meta/FileMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/FileMetadataExtractor.java
@@ -20,7 +20,10 @@ import gov.nasa.pds.harvest.cfg.model.Configuration;
 import gov.nasa.pds.harvest.util.CloseUtils;
 import gov.nasa.pds.harvest.util.out.FieldNameUtils;
 
-
+/**
+ * Extracts file metadata, such as file name, size, checksum.
+ * @author karpenko
+ */
 public class FileMetadataExtractor
 {
     private FileInfoCfg fileInfoCfg;
@@ -30,6 +33,11 @@ public class FileMetadataExtractor
     private Tika tika;
 
     
+    /**
+     * Constructor
+     * @param config configuration
+     * @throws Exception and exception
+     */
     public FileMetadataExtractor(Configuration config) throws Exception
     {
         this.fileInfoCfg = config.fileInfo;
@@ -41,8 +49,14 @@ public class FileMetadataExtractor
             tika = new Tika();
         }
     }
+
     
-    
+    /**
+     * Extract file metadata
+     * @param file a file
+     * @param meta extracted metadata is added to this object
+     * @throws Exception an exception
+     */
     public void extract(File file, Metadata meta) throws Exception
     {
         if(fileInfoCfg == null) return;

--- a/src/main/java/gov/nasa/pds/harvest/meta/InternalReferenceExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/InternalReferenceExtractor.java
@@ -11,6 +11,10 @@ import gov.nasa.pds.harvest.util.FieldMapSet;
 import gov.nasa.pds.harvest.util.xml.XPathUtils;
 
 
+/**
+ * Extracts internal references
+ * @author karpenko
+ */
 public class InternalReferenceExtractor
 {
 //////////////////////////////////////////////////////////
@@ -27,13 +31,23 @@ public class InternalReferenceExtractor
     private XPathExpression xIntRef;
     
     
+    /**
+     * Constructor
+     * @throws Exception an exception
+     */
     public InternalReferenceExtractor() throws Exception
     {
         XPathFactory xpf = XPathFactory.newInstance();
         xIntRef = XPathUtils.compileXPath(xpf, "//Internal_Reference");
     }
     
-    
+
+    /**
+     * Adds internal references to a field map
+     * @param fmap multi-valued field map
+     * @param doc parsed PDS label (XML DOM) 
+     * @throws Exception an exception
+     */
     public void addRefs(FieldMapSet fmap, Document doc) throws Exception
     {
         NodeList nodes = XPathUtils.getNodeList(doc, xIntRef);        

--- a/src/main/java/gov/nasa/pds/harvest/meta/Metadata.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/Metadata.java
@@ -26,7 +26,10 @@ public class Metadata
     
     public Set<String> dataFiles;
 
-    
+
+    /**
+     * Constructor
+     */
     public Metadata()
     {
         intRefs = new FieldMapSet();

--- a/src/main/java/gov/nasa/pds/harvest/meta/SearchMetadataExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/SearchMetadataExtractor.java
@@ -1,0 +1,80 @@
+package gov.nasa.pds.harvest.meta;
+
+import org.apache.commons.lang.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import gov.nasa.pds.harvest.util.FieldMap;
+
+/**
+ * Extract metadata used by keyword / full-text search
+ * @author karpenko
+ */
+public class SearchMetadataExtractor
+{
+    private FieldMap fields;
+    
+    /**
+     * Constructor
+     */
+    public SearchMetadataExtractor()
+    {
+    }
+
+    
+    /**
+     * Extracts search fields from a parsed label file (XML DOM) into a FieldMap
+     * @param doc Parsed PDS label file (XML DOM)
+     * @param fields key-value pairs (output parameter)
+     * @throws Exception an exception
+     */
+    public void extract(Document doc, FieldMap fields) throws Exception
+    {
+        this.fields = fields;
+        
+        Element root = doc.getDocumentElement();
+        processNode(root);
+        
+        // Release reference
+        this.fields = null;
+    }
+
+    
+    private void processNode(Node node) throws Exception
+    {
+        boolean isLeaf = true;
+        
+        NodeList nl = node.getChildNodes();
+        for(int i = 0; i < nl.getLength(); i++)
+        {
+            Node cn = nl.item(i);
+            if(cn.getNodeType() == Node.ELEMENT_NODE)
+            {
+                isLeaf = false;
+                // Process children recursively
+                processNode(cn);
+            }
+        }
+        
+        // This is a leaf node. Get value.
+        if(isLeaf)
+        {
+            processLeafNode(node);
+        }
+    }
+    
+    
+    private void processLeafNode(Node node) throws Exception
+    {
+        String name = node.getNodeName();
+        
+        if("description".equals(name))
+        {
+            String value = StringUtils.normalizeSpace(node.getTextContent());
+            fields.addValue("description", value);
+        }
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/harvest/meta/XPathCacheLoader.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/XPathCacheLoader.java
@@ -17,19 +17,30 @@ import gov.nasa.pds.harvest.util.xml.XPathUtils;
 import gov.nasa.pds.harvest.util.xml.XmlDomUtils;
 
 
+/**
+ * Loads XPaths from a configuration file into XPath cache. 
+ * @author karpenko
+ */
 public class XPathCacheLoader
 {
     private Logger LOG;
     private XPathFactory xpf;
     
-    
+    /**
+     * Constructor
+     */
     public XPathCacheLoader()
     {
         LOG = LogManager.getLogger(getClass());
         xpf = XPathFactory.newInstance();
     }
     
-    
+
+    /**
+     * Load XPaths from a configuration file
+     * @param maps XPath configuration (parsed configuration file) 
+     * @throws Exception
+     */
     public void load(XPathMapCfg maps) throws Exception
     {
         if(maps == null || maps.items == null || maps.items.isEmpty()) return;

--- a/src/main/java/gov/nasa/pds/harvest/meta/XPathCacheManager.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/XPathCacheManager.java
@@ -5,6 +5,11 @@ import java.util.Map;
 
 import gov.nasa.pds.harvest.util.xml.XPathCache;
 
+
+/**
+ * A singleton. Manages references to a common cache and object caches.
+ * @author karpenko
+ */
 public class XPathCacheManager
 {
     private static XPathCacheManager instance = new XPathCacheManager();
@@ -12,25 +17,41 @@ public class XPathCacheManager
     private XPathCache commonCache;
     private Map<String, XPathCache> cacheMap;
     
-    
+
+    /**
+     * Private constructor. Use getInstance() instead.
+     */
     private XPathCacheManager()
     {
         cacheMap = new HashMap<>();
     }
 
 
+    /**
+     * Get singleton instance.
+     * @return a singleton
+     */
     public static XPathCacheManager getInstance()
     {
         return instance;
     }
 
-    
+
+    /**
+     * Get common cache.
+     * @return a common XPath ache.
+     */
     public XPathCache getCommonCache()
     {
         return commonCache;
     }
 
-    
+
+    /**
+     * Get a cache by object type, e.g., "Product_Collection"
+     * @param type object type
+     * @return XPath cache
+     */
     public XPathCache getCacheByObjectType(String type)
     {
         return (type == null) ? commonCache : cacheMap.get(type);

--- a/src/main/java/gov/nasa/pds/harvest/meta/XPathExtractor.java
+++ b/src/main/java/gov/nasa/pds/harvest/meta/XPathExtractor.java
@@ -24,7 +24,13 @@ public class XPathExtractor
         dateConverter = new PdsDateConverter(true);
     }
 
-    
+
+    /**
+     * Extract metadata from a PDS label by XPath
+     * @param doc parsed PDS label (XML DOM)
+     * @param fields extracted metadata is added to this object
+     * @throws Exception an exception
+     */
     public void extract(Document doc, FieldMap fields) throws Exception
     {
         String rootElement = doc.getDocumentElement().getNodeName();

--- a/src/test/java/tt/es/EmbeddedBlobExporter.java
+++ b/src/test/java/tt/es/EmbeddedBlobExporter.java
@@ -1,0 +1,67 @@
+package tt.es;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+import java.util.zip.InflaterInputStream;
+
+
+/**
+ * Few methods to export a BLOB to a file.
+ * 
+ * @author karpenko
+ */
+public class EmbeddedBlobExporter
+{
+    
+    /**
+     * Export Base64 encoded string into a file
+     * @param blob Base64 encoded string
+     * @param filePath output file path
+     * @throws Exception an exception
+     */
+    public static void export(String blob, String filePath) throws Exception
+    {
+        byte[] data = Base64.getDecoder().decode(blob);
+        export(data, filePath);
+    }
+    
+    
+    /**
+     * Export binary data into a file
+     * @param blob raw data
+     * @param filePath output file path
+     * @throws Exception an exception
+     */
+    public static void export(byte[] blob, String filePath) throws Exception
+    {
+        ByteArrayInputStream bais = new ByteArrayInputStream(blob);
+        InflaterInputStream source = new InflaterInputStream(bais);
+
+        FileOutputStream dest = new FileOutputStream(filePath);
+    
+        copy(source, dest);
+        dest.close();
+    }
+
+
+    /**
+     * Copy data from input to output stream
+     * @param source source stream
+     * @param dest destination stream
+     * @throws Exception an exception
+     */
+    private static void copy(InputStream source, OutputStream dest) throws Exception
+    {
+        byte[] buf = new byte[1024];
+
+        int count = 0;
+        while((count = source.read(buf)) >= 0)
+        {
+            dest.write(buf, 0, count);
+        }
+    }
+
+}

--- a/src/test/java/tt/es/TestXml2Json.java
+++ b/src/test/java/tt/es/TestXml2Json.java
@@ -1,0 +1,37 @@
+package tt.es;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+
+import org.json.JSONObject;
+import org.json.XML;
+
+import gov.nasa.pds.harvest.meta.FileMetadataExtractor;
+
+public class TestXml2Json
+{
+    public static void main(String[] args) throws Exception
+    {
+        test1();
+    }
+    
+    public static void test2() throws Exception
+    {
+        File file = new File("/tmp/d1/1294638283.xml");
+        String blob = FileMetadataExtractor.getJsonBlob(file);                
+        System.out.println(blob);
+        
+        EmbeddedBlobExporter.export(blob, "/tmp/blob.json");
+    }
+    
+    
+    public static void test1() throws Exception
+    {
+        Reader xmlSource = new FileReader("/tmp/d1/1294638283.xml");
+        JSONObject json = XML.toJSONObject(xmlSource);
+        String str = json.toString();
+        System.out.println(str);
+    }
+
+}


### PR DESCRIPTION
**Summary**
- Added SearchMetadataExtractor class to extract metadata for full-text / keyword search. For now it only handles description fields, but could be extended in the future.
-  Generate label BLOBs by default. Log warning if BLOBs are disabled. See #58.
- Added more comments.

**Test Instructions**
- Harvest a PDS label.
- Check that all description fields are copied to new multivalued field "description".
