### PR TITLE
Close all open files on error

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/cmd/CrawlerCmd.java
+++ b/src/main/java/gov/nasa/pds/harvest/cmd/CrawlerCmd.java
@@ -63,17 +63,22 @@ public class CrawlerCmd implements CliCommand
 
         RegistryManager.init(cfg.registryCfg);
 
-        if(cfg.dirs != null)
+        try
         {
-            processDirs();
+            if(cfg.dirs != null)
+            {
+                processDirs();
+            }
+            else if(cfg.bundles != null)
+            {
+                processBundles();
+            }
         }
-        else if(cfg.bundles != null)
+        finally
         {
-            processBundles();
+            WriterManager.destroy();
+            RegistryManager.destroy();
         }
-
-        WriterManager.destroy();
-        RegistryManager.destroy();
         
         printSummary();
     }


### PR DESCRIPTION
## 🗒️ Summary
I/O or XML parse error caused corruption of output JSON files.
FIX: Close all open files on error.

## ⚙️ Test Instructions
- Create a directory for test data files, e.g., `/tmp/test`, 
- Copy few valid PDS labels to this folder. You may also need to copy corresponding data files or disable data file processing in harvest config file.
- Also create an invalid XML file in the same directory, for example, `x.xml` with some invalid content like, `kdfdfkdjf;'dkflkf`.
- Run Harvest to process files from your test folder. `harvest -c /my/test/harvest-cfg.xml`
- You can configure your test directory in you Harvest config file (`/my/test/harvest-cfg.xml`) as follows:
 ```
<directories>
    <path>/tmp/test</path>
</directories>

<!-- Disable processing of data files -->
<fileInfo processDataFiles="false" storeLabels="false" storeJsonLabels="false">
    <fileRef replacePrefix="/tmp/" with="http://test.local/"/>
</fileInfo>
``` 
- NOTE: Make sure that harvest starts processing the invalid XML file after few valid labels. Depending on an operating system file order can be different. On my machine files were processed in alphabetical / update timestamp order, for example:
```
bundle_kaguya_derived.xml     - VALID
orex.xml                      - VALID
x.xml                         - INVALID
```
- Harvest should fail with an error like this:
```
[ERROR] Could not parse file /tmp/test/x.xml. Content is not allowed in prolog. (line = 1, column = 1).
```
- Check JSON files in harvest output directory, such as `/tmp/harvest/out` (default). Make sure they are not corrupted (cut off in the middle of a field name or value.)
- NOTE: Output JSON files are NJSON files (new line terminated JSON). Each line contains its own JSON.

## ♻️ Related Issues
https://github.com/NASA-PDS/pds-registry-app/issues/205

