### PR TITLE
Trim spaces in manifest file

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/crawler/FilesProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/FilesProcessor.java
@@ -163,7 +163,7 @@ public class FilesProcessor
             while((line = rd.readLine()) != null)
             {
                 if(line.length() == 0 || line.startsWith("#")) continue;
-                File file = new File(line);
+                File file = new File(line.trim());
                 onFile(file);
             }
         }


### PR DESCRIPTION
## 🗒️ Summary
Usually this should not happen, but I decided to fix this.
Trim spaces in file paths in a manifest file, for example, (spaces replaced with '_')
```
_____/tmp/d2/ftir_cube_wvlns.xml_______
```

## ⚙️ Test Data and/or Report
The same as previous merge request.
Harvest config:
```
  <files>
    <manifest>/tmp/manifest.txt</manifest>
  </files>
```
Manifest with some spaces before or after a file name.


