### PR TITLE
Continue after the ingestion of a product fails

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -106,10 +106,10 @@ public class HarvestCli
         System.out.println("  -V, --version      Print Harvest version");
         System.out.println();
         System.out.println("Optional parameters:");
-        System.out.println("  -o <dir>      Output directory. Default is /tmp/harvest/out");
-        System.out.println("  -l <file>     Log file. Default is /tmp/harvest/harvest.log");
-        System.out.println("  -v <level>    Logger verbosity: DEBUG, INFO (default), WARNING, ERROR");
-        System.out.println("  -overwrite    Overwrite registered products");
+        System.out.println("  -o <dir>           Output directory. Default is /tmp/harvest/out");
+        System.out.println("  -l <file>          Log file. Default is /tmp/harvest/harvest.log");
+        System.out.println("  -v <level>         Logger verbosity: DEBUG, INFO (default), WARNING, ERROR");
+        System.out.println("  -O, --overwrite    Overwrite registered products");
     }
 
     
@@ -194,7 +194,7 @@ public class HarvestCli
         bld = Option.builder("v").hasArg().argName("level");
         options.addOption(bld.build());
         
-        bld = Option.builder("overwrite");
+        bld = Option.builder("O").longOpt("overwrite");
         options.addOption(bld.build());
     }
 

--- a/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -106,7 +106,8 @@ public class HarvestCli
         System.out.println("  -V, --version      Print Harvest version");
         System.out.println();
         System.out.println("Optional parameters:");
-        System.out.println("  -o <dir>           Output directory. Default is /tmp/harvest/out");
+        System.out.println("  -o <dir>           Output directory (applies to supplemental products only)."); 
+        System.out.println("                     Default is /tmp/harvest/out");
         System.out.println("  -l <file>          Log file. Default is /tmp/harvest/harvest.log");
         System.out.println("  -v <level>         Logger verbosity: DEBUG, INFO (default), WARNING, ERROR");
         System.out.println("  -O, --overwrite    Overwrite registered products");

--- a/src/main/java/gov/nasa/pds/harvest/cmd/HarvestCmd.java
+++ b/src/main/java/gov/nasa/pds/harvest/cmd/HarvestCmd.java
@@ -278,19 +278,18 @@ public class HarvestCmd implements CliCommand
         int processedCount = counter.prodCounters.getTotal();
         
         log.log(LogUtils.LEVEL_SUMMARY, "Skipped files: " + counter.skippedFileCount);
-        log.log(LogUtils.LEVEL_SUMMARY, "Failed files: " + counter.errorFileCount);
-        log.log(LogUtils.LEVEL_SUMMARY, "Processed files: " + processedCount);
+        log.log(LogUtils.LEVEL_SUMMARY, "Loaded files: " + processedCount);
         
         if(processedCount > 0)
         {
-            log.log(LogUtils.LEVEL_SUMMARY, "File counts by type:");
             for(CounterMap.Item item: counter.prodCounters.getCounts())
             {
                 log.log(LogUtils.LEVEL_SUMMARY, "  " + item.name + ": " + item.count);
             }
-            
-            log.log(LogUtils.LEVEL_SUMMARY, "Package ID: " + PackageIdGenerator.getInstance().getPackageId());
         }
+        
+        log.log(LogUtils.LEVEL_SUMMARY, "Failed files: " + counter.failedFileCount);
+        log.log(LogUtils.LEVEL_SUMMARY, "Package ID: " + PackageIdGenerator.getInstance().getPackageId());
     }
 
 }

--- a/src/main/java/gov/nasa/pds/harvest/cmd/HarvestCmd.java
+++ b/src/main/java/gov/nasa/pds/harvest/cmd/HarvestCmd.java
@@ -278,6 +278,7 @@ public class HarvestCmd implements CliCommand
         int processedCount = counter.prodCounters.getTotal();
         
         log.log(LogUtils.LEVEL_SUMMARY, "Skipped files: " + counter.skippedFileCount);
+        log.log(LogUtils.LEVEL_SUMMARY, "Failed files: " + counter.errorFileCount);
         log.log(LogUtils.LEVEL_SUMMARY, "Processed files: " + processedCount);
         
         if(processedCount > 0)

--- a/src/main/java/gov/nasa/pds/harvest/crawler/Counter.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/Counter.java
@@ -11,6 +11,7 @@ public class Counter
 {
     public CounterMap prodCounters;
     public int skippedFileCount;
+    public int errorFileCount;
     
     public Counter()
     {

--- a/src/main/java/gov/nasa/pds/harvest/crawler/Counter.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/Counter.java
@@ -11,7 +11,7 @@ public class Counter
 {
     public CounterMap prodCounters;
     public int skippedFileCount;
-    public int errorFileCount;
+    public int failedFileCount;
     
     public Counter()
     {

--- a/src/main/java/gov/nasa/pds/harvest/crawler/FilesProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/FilesProcessor.java
@@ -157,7 +157,7 @@ public class FilesProcessor extends BaseProcessor
         catch(Exception ex)
         {
             log.error(ex.getMessage());
-            counter.errorFileCount++;
+            counter.failedFileCount++;
             return;
         }        
         
@@ -181,7 +181,7 @@ public class FilesProcessor extends BaseProcessor
         catch(Exception ex)
         {
             log.error(ex.getMessage());
-            counter.errorFileCount++;
+            counter.failedFileCount++;
         }        
     }
 

--- a/src/main/java/gov/nasa/pds/harvest/crawler/FilesProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/FilesProcessor.java
@@ -156,8 +156,8 @@ public class FilesProcessor extends BaseProcessor
         }
         catch(Exception ex)
         {
-            log.warn(ex.getMessage());
-            counter.skippedFileCount++;
+            log.error(ex.getMessage());
+            counter.errorFileCount++;
             return;
         }        
         
@@ -173,7 +173,16 @@ public class FilesProcessor extends BaseProcessor
             if(config.filters.prodClassExclude.contains(rootElement)) return;
         }
         
-        processMetadata(file, doc);
+        // Process metadata
+        try
+        {
+            processMetadata(file, doc);
+        }
+        catch(Exception ex)
+        {
+            log.error(ex.getMessage());
+            counter.errorFileCount++;
+        }        
     }
 
     
@@ -193,21 +202,10 @@ public class FilesProcessor extends BaseProcessor
 
         String rootElement = doc.getDocumentElement().getNodeName();
 
-        // Process Collection specific data
-        if("Product_Collection".equals(rootElement))
-        {
-            processInventoryFiles(file, doc, meta);
-        }
         // Process Bundle specific data
-        else if("Product_Bundle".equals(rootElement))
+        if("Product_Bundle".equals(rootElement))
         {
             addCollectionRefs(meta, doc);
-        }
-        // Process supplemental products
-        else if("Product_Metadata_Supplemental".equals(rootElement))
-        {
-            SupplementalWriter swriter = WriterManager.getInstance().getSupplementalWriter();
-            swriter.write(file);
         }
         
         // Internal references
@@ -227,6 +225,18 @@ public class FilesProcessor extends BaseProcessor
         
         // Save data
         save(meta, nsInfo);
+        
+        // Process Collection inventory
+        if("Product_Collection".equals(rootElement))
+        {
+            processInventoryFiles(file, doc, meta);
+        }
+        // Process supplemental products
+        else if("Product_Metadata_Supplemental".equals(rootElement))
+        {
+            SupplementalWriter swriter = WriterManager.getInstance().getSupplementalWriter();
+            swriter.write(file);
+        }
     }
 
     

--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -137,7 +137,7 @@ public class ProductProcessor extends BaseProcessor
         catch(Exception ex)
         {
             log.warn(ex.getMessage());
-            counter.errorFileCount++;
+            counter.failedFileCount++;
             return;
         }        
         
@@ -164,7 +164,7 @@ public class ProductProcessor extends BaseProcessor
         catch(Exception ex)
         {
             log.error(ex.getMessage());
-            counter.errorFileCount++;
+            counter.failedFileCount++;
         }        
     }
     

--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -137,7 +137,7 @@ public class ProductProcessor extends BaseProcessor
         catch(Exception ex)
         {
             log.warn(ex.getMessage());
-            counter.skippedFileCount++;
+            counter.errorFileCount++;
             return;
         }        
         
@@ -156,7 +156,16 @@ public class ProductProcessor extends BaseProcessor
             if(config.filters.prodClassExclude.contains(rootElement)) return;
         }
 
-        processMetadata(file, doc);
+        // Process metadata
+        try
+        {
+            processMetadata(file, doc);
+        }
+        catch(Exception ex)
+        {
+            log.error(ex.getMessage());
+            counter.errorFileCount++;
+        }        
     }
     
     

--- a/src/main/java/gov/nasa/pds/harvest/dao/MetadataWriter.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/MetadataWriter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -89,6 +90,7 @@ public class MetadataWriter implements Closeable
             }
         }
 
+        // Build JSON documents for Elasticsearch
         List<String> data = new ArrayList<>();
         
         for(RegistryDocBatch.NJsonItem item: docBatch.getItems())
@@ -111,9 +113,34 @@ public class MetadataWriter implements Closeable
             }
         }
         
-        totalRecords += loader.loadBatch(data);
+        // Load batch
+        Set<String> failedIds = new TreeSet<>();
+        totalRecords += loader.loadBatch(data, failedIds);
         log.info("Wrote " + totalRecords + " product(s)");
         
+        // Update failed counter
+        counter.failedFileCount += failedIds.size();
+
+        // Update product counters
+        for(RegistryDocBatch.NJsonItem item: docBatch.getItems())
+        {
+            if(nonRegisteredIds == null)
+            {
+                if(!failedIds.contains(item.lidvid)) 
+                {
+                    counter.prodCounters.inc(item.prodClass);
+                }
+            }
+            else
+            {
+                if(nonRegisteredIds.contains(item.lidvid) && !failedIds.contains(item.lidvid))
+                {
+                    counter.prodCounters.inc(item.prodClass);
+                }
+            }
+        }
+        
+        // Clear batch
         docBatch.clear();
     }
 
@@ -122,8 +149,6 @@ public class MetadataWriter implements Closeable
     {
         data.add(item.pkJson);
         data.add(item.dataJson);
-
-        counter.prodCounters.inc(item.prodClass);
     }
     
     

--- a/src/main/java/gov/nasa/pds/harvest/dao/MetadataWriter.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/MetadataWriter.java
@@ -124,19 +124,10 @@ public class MetadataWriter implements Closeable
         // Update product counters
         for(RegistryDocBatch.NJsonItem item: docBatch.getItems())
         {
-            if(nonRegisteredIds == null)
+            if((nonRegisteredIds == null && !failedIds.contains(item.lidvid)) ||
+               (nonRegisteredIds != null && nonRegisteredIds.contains(item.lidvid) && !failedIds.contains(item.lidvid)))
             {
-                if(!failedIds.contains(item.lidvid)) 
-                {
-                    counter.prodCounters.inc(item.prodClass);
-                }
-            }
-            else
-            {
-                if(nonRegisteredIds.contains(item.lidvid) && !failedIds.contains(item.lidvid))
-                {
-                    counter.prodCounters.inc(item.prodClass);
-                }
+                counter.prodCounters.inc(item.prodClass);
             }
         }
         


### PR DESCRIPTION
## 🗒️ Summary
Continue ingesting other products after the ingestion of a product fails.

**NOTE: Valid use cases:** 
* If you are ingesting a directory (`<directories>` configuration) or a manifest (`<files>` configuration), Harvest will continue after any product failure.
* If you are ingesting a bundle (`<bundles>` configuration), Harvest will stop if the bundle or a collection ingestion fails. It will continue if any non-bundle or non-collection product type fails, such as an Observational product.
 
## ⚙️ Test Data and/or Report
* Build commons project first (see https://github.com/NASA-PDS/registry-common/pull/23)
* Then build Harvest
* Before ingesting data make one or more products invalid. For example, set `<start_date_time>` = "ABC" or `<field_number>` = "XYZ".
* Run Harvest (use `-O` (overwrite) flag if you loaded the same data before)
* Check that products with errors are skipped and valid products are loaded. See NOTE above for valid use cases.

## ♻️ Related Issues
https://github.com/NASA-PDS/pds-registry-app/issues/253
https://github.com/NASA-PDS/harvest/issues/84
