### PR TITLE
Fixed Linux startup script

### DIFF
--- a/src/main/resources/bin/harvest
+++ b/src/main/resources/bin/harvest
@@ -50,6 +50,7 @@ fi
 # Home
 SCRIPT_DIR=$(cd "$( dirname $0 )" && pwd)
 HARVEST_HOME=$(cd ${SCRIPT_DIR}/.. && pwd)
+export HARVEST_HOME
 
 # Executable Jar
 TOOL_JARS=(${HARVEST_HOME}/dist/harvest-*.jar)


### PR DESCRIPTION
## 🗒️ Summary
Fixed Linux startup script

## ⚙️ Test Data and/or Report
Run Harvest on Linux and make sure there is no following error:
```
[ERROR] Could not find default configuration directory. HARVEST_HOME environment variable is not set.
```

## ♻️ Related Issues
