### PR TITLE
Fixed truncation of trailing zeros in LIDVID

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/dao/RegistryDocBatch.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/RegistryDocBatch.java
@@ -36,7 +36,7 @@ public class RegistryDocBatch
     public void write(Metadata meta, String jobId) throws Exception
     {
         NJsonItem item = new NJsonItem();
-        item.lidvid = meta.lid + "::" + meta.vid;
+        item.lidvid = meta.lidvid;
         item.prodClass = meta.prodClass;
         item.pkJson = RegistryDocBuilder.createPKJson(meta);
         item.dataJson = RegistryDocBuilder.createDataJson(meta, jobId);


### PR DESCRIPTION
## 🗒️ Summary
Fixed `_id` and `lidvid` field generator to not truncate trailing zeros of a version id.

## ⚙️ Test Data and/or Report
**NOTE:**  Build commons project first. See https://github.com/NASA-PDS/registry-common/pull/25

1. Create a label with the `version_id` field containing trailing zeros, for example, `1.10`
2. Run Harvest to Ingest the label.
3. Check the `lidvid` and `_id` fields in OpenSearch / Elasticsearch.

## ♻️ Related Issues
resolves https://github.com/NASA-PDS/harvest/issues/90
