### PR TITLE
FIX Possible null pointer exception and UPDATE error message in createSearchIdsRequest() 

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/dao/EsRequestBuilder.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/EsRequestBuilder.java
@@ -57,7 +57,8 @@ public class EsRequestBuilder
      */
     public String createSearchIdsRequest(Collection<String> ids, int pageSize) throws Exception
     {
-        if(ids == null || ids.isEmpty()) throw new Exception("Missing ids");
+        if(ids == null || ids.isEmpty()) throw new Exception("Error reading bundle/collection references. " +
+                "Verify the bundle is valid prior to loading the data.");
             
         StringWriter out = new StringWriter();
         JsonWriter writer = createJsonWriter(out);

--- a/src/main/java/gov/nasa/pds/harvest/dao/EsRequestBuilder.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/EsRequestBuilder.java
@@ -1,10 +1,12 @@
 package gov.nasa.pds.harvest.dao;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Collection;
 
 import com.google.gson.stream.JsonWriter;
+import gov.nasa.pds.harvest.exception.InvalidPDS4ProductException;
 
 
 /**
@@ -53,12 +55,12 @@ public class EsRequestBuilder
      * @param ids Collection of product IDs (lidvids)
      * @param pageSize Number of records to return. Usually pageSize = ids.size().
      * @return JSON Elasticsearch request
-     * @throws Exception Generic exception
+     * @throws InvalidPDS4ProductException Invalid PDS4 Product Exception
+     * @throws IOException IOException
      */
-    public String createSearchIdsRequest(Collection<String> ids, int pageSize) throws Exception
-    {
-        if(ids == null || ids.isEmpty()) throw new Exception("Error reading bundle/collection references. " +
-                "Verify the bundle is valid prior to loading the data.");
+    public String createSearchIdsRequest(Collection<String> ids, int pageSize) throws InvalidPDS4ProductException, IOException {
+        if(ids == null || ids.isEmpty()) throw new InvalidPDS4ProductException("Error reading bundle/collection references. " +
+                "Verify the bundle/collection is valid prior to loading the data.");
             
         StringWriter out = new StringWriter();
         JsonWriter writer = createJsonWriter(out);

--- a/src/main/java/gov/nasa/pds/harvest/dao/RegistryDao.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/RegistryDao.java
@@ -2,6 +2,7 @@ package gov.nasa.pds.harvest.dao;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -75,13 +76,12 @@ public class RegistryDao
      * Check if given product IDs (lidvids) exist in Elasticsearch "registry" 
      * collection. Return values that don't exist in Elasticsearch.
      * @param ids Search these IDs (lidvids) in Elasticsearch
-     * @param pageSize max number of results to return. Usually pageSize = ids.size()
      * @return a list of product IDs (lidvids) that don't exist in Elasticsearch "registry" collection.
      * @throws Exception Generic exception
      */
     public Set<String> getNonExistingIds(Collection<String> ids) throws Exception
     {
-        if(ids == null || ids.isEmpty()) return null;
+        if(ids == null || ids.isEmpty()) return new HashSet<>();
         Response resp = searchIds(ids);
 
         NonExistingIdsResponse idsResp = new NonExistingIdsResponse(ids);

--- a/src/main/java/gov/nasa/pds/harvest/exception/InvalidPDS4ProductException.java
+++ b/src/main/java/gov/nasa/pds/harvest/exception/InvalidPDS4ProductException.java
@@ -1,0 +1,11 @@
+package gov.nasa.pds.harvest.exception;
+
+/**
+ * InvalidPDS4ProductException is a custom exception to throw when there is an
+ * error reading bundle/collection references.
+ */
+public class InvalidPDS4ProductException extends Exception {
+    public InvalidPDS4ProductException(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
FIX Possible null pointer exception in idExists(String id), when calling retIds.isEmpty()
UPDATE error message in createSearchIdsRequest() method when ids == null || ids.isEmpty()

## 🗒️ Summary

In the following [code](https://github.com/NASA-PDS/harvest/blob/73833d62f5810a441aaf70eab055cda57fb9cec0/src/main/java/gov/nasa/pds/harvest/dao/RegistryDao.java#L84)  it returns `null` when `(ids == null || ids.isEmpty())`.

```java
public Set<String> getNonExistingIds(Collection<String> ids) throws Exception
    {
        if(ids == null || ids.isEmpty()) return null;
        Response resp = searchIds(ids);

        NonExistingIdsResponse idsResp = new NonExistingIdsResponse(ids);
        parser.parseResponse(resp, idsResp);

        return idsResp.getIds();
    }
```

However, above method is called by [idExists(String id) ](https://github.com/NASA-PDS/harvest/blob/73833d62f5810a441aaf70eab055cda57fb9cec0/src/main/java/gov/nasa/pds/harvest/dao/RegistryDao.java#L70) and it is expecting to have a non-null `retIds` object to call `retIds.isEmpty();`.

```java
public boolean idExists(String id) throws Exception
    {
        List<String> ids = new ArrayList<>(1);
        ids.add(id);
        
        Collection<String> retIds = getNonExistingIds(ids);
        return retIds.isEmpty();
    }
```

The `getNonExistingIds(Collection<String> ids)` should return an empty `Set<String>` instead of `null`, when  `(ids == null || ids.isEmpty())`.


## ♻️ Related Issues
Refer to the issue NASA-PDS/harvest#96


