### PR TITLE
Issue 106 - add descriptive detail to skipped product log message

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -187,7 +187,7 @@ public class ProductProcessor extends BaseProcessor
         LidVidCache cache = RefsCache.getInstance().getProdRefsCache();
         if(!cache.containsLidVid(meta.lidvid) && !cache.containsLid(meta.lid)) 
         {
-            log.info("Skipping product " + file.getAbsolutePath());
+            log.info("Skipping product " + file.getAbsolutePath() + " (LIDVID/LID is not in collection inventory or is already registered in Elasticsearch)");
             counter.skippedFileCount++;
             return;
         }


### PR DESCRIPTION
## 🗒️ Summary
Adds descriptive content to skipped product log message

## ⚙️ Test Data and/or Report
Due to the trivial nature of the change (famous last words), no testing has been performed, to save the time/effort of understanding/setting up the necessary test inputs.

It's inobvious how to run the local unit tests, so they're skipped too - if that's unacceptable, kick it back to me.

## ♻️ Related Issues
fixes #106 