### PR TITLE
make Product/Collection/Bundle processors respect RegistryManager's o…

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/BundleProcessor.java
@@ -129,9 +129,11 @@ public class BundleProcessor extends BaseProcessor
         
         RegistryDao dao = RegistryManager.getInstance().getRegistryDao(); 
         Counter counter = RegistryManager.getInstance().getCounter();
-        
-        // Bundle already registered in the Registry (Elasticsearch)
-        if(dao.idExists(meta.lidvid))
+
+        boolean bundleAlreadyRegistered = dao.idExists(meta.lidvid);
+        boolean overwriteMode = RegistryManager.getInstance().isOverwrite();
+
+        if(bundleAlreadyRegistered && !overwriteMode)
         {
             log.warn("Bundle " + meta.lidvid + " already registered. Skipping.");
             addCollectionRefs(meta, doc);

--- a/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/CollectionProcessor.java
@@ -136,8 +136,10 @@ public class CollectionProcessor extends BaseProcessor
         RegistryDao dao = RegistryManager.getInstance().getRegistryDao();
         Counter counter = RegistryManager.getInstance().getCounter();
 
-        // Collection already registered in the Registry (Elasticsearch)
-        if(dao.idExists(meta.lidvid))
+        boolean overwriteMode = RegistryManager.getInstance().isOverwrite();
+        boolean collectionAlreadyRegistered = dao.idExists(meta.lidvid);
+
+        if(collectionAlreadyRegistered && !overwriteMode)
         {
             log.warn("Collection " + meta.lidvid + " already registered. Skipping.");
             

--- a/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
+++ b/src/main/java/gov/nasa/pds/harvest/crawler/ProductProcessor.java
@@ -185,7 +185,12 @@ public class ProductProcessor extends BaseProcessor
 
         // Only process primary products from collection inventory
         LidVidCache cache = RefsCache.getInstance().getProdRefsCache();
-        if(!cache.containsLidVid(meta.lidvid) && !cache.containsLid(meta.lid)) 
+        // productNotInCache may be equivalent to productAlreadyRegistered, but it's unclear if there are other factors
+        // which might result in this being true, so I'm keeping it explicit until I know otherwise
+        boolean productNotInCache = !cache.containsLidVid(meta.lidvid) && !cache.containsLid(meta.lid);
+        boolean overwriteMode = RegistryManager.getInstance().isOverwrite();
+
+        if(productNotInCache && !overwriteMode)
         {
             log.info("Skipping product " + file.getAbsolutePath() + " (LIDVID/LID is not in collection inventory or is already registered in Elasticsearch)");
             counter.skippedFileCount++;


### PR DESCRIPTION
…verwrite option

## 🗒️ Summary
Adds respect for `RegistryManager` overwrite mode (set by `--overwrite` option) to [product target approaches where it was previously missing](https://github.com/NASA-PDS/harvest/issues/112)

## ⚙️ Test Data and/or Report
Manual testing only

## ♻️ Related Issues
fixes #112 


