### PR TITLE
Update harvest to support `ByteOrderMark` (BOM) as its first bytes

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/util/xml/XmlIs.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/xml/XmlIs.java
@@ -1,8 +1,9 @@
 package gov.nasa.pds.harvest.util.xml;
 
-import java.io.FileReader;
+import java.io.FileInputStream;
 import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
+import org.apache.commons.io.input.BOMInputStream;
 import org.xml.sax.InputSource;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.ParseOptions;
@@ -22,7 +23,7 @@ public class XmlIs {
         ParseOptions options = new ParseOptions();
         options.withLineNumbering(true);
         options.withXIncludeAware(false);
-        Source source = new SAXSource(new InputSource(new FileReader(filename)));
+        Source source = new SAXSource(new InputSource(new BOMInputStream(new FileInputStream(filename))));
         TreeInfo docInfo = configuration.buildDocumentTree(source , options);
         NodeInfo ia=null,lid=null,pcls=null;
         for (NodeInfo top : docInfo.getRootNode().children()) {

--- a/src/test/java/harvest/util/xml/XmlIsSuite.java
+++ b/src/test/java/harvest/util/xml/XmlIsSuite.java
@@ -7,6 +7,7 @@ import gov.nasa.pds.harvest.util.xml.XmlIs;
 class XmlIsSuite {
   @Test
   void testBundle() {
+    assertTrue(XmlIs.aBundle ("src/test/resources/github141/bundle_hausrath_m2020_pixl_naltsos.xml"));
     assertTrue(XmlIs.aBundle ("src/test/resources/test_data/sample_dossier.lblx"));
     assertFalse(XmlIs.aBundle ("src/test/resources/test_data/document/collection_document.lblx"));
     assertFalse(XmlIs.aBundle ("src/test/resources/test_data/document/sample_dossier_release_notes.lblx"));

--- a/src/test/resources/github141/bundle_hausrath_m2020_pixl_naltsos.xml
+++ b/src/test/resources/github141/bundle_hausrath_m2020_pixl_naltsos.xml
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1I00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Bundle xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1I00.xsd">
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:hausrath_m2020_pixl_naltsos</logical_identifier>
+    <version_id>1.1</version_id>
+    <title>An Examination of Soil Crusts on the Floor of Jezero crater, Mars</title>
+    <information_model_version>1.18.0.0</information_model_version>
+    <product_class>Product_Bundle</product_class>
+    <Citation_Information>
+      <author_list>Hausrath, E. M.</author_list>
+      <editor_list>VanBommel, S. J.</editor_list>
+      <publication_year>2022</publication_year>
+      <doi>10.17189/vnph-f562</doi>
+      <description>
+        An Examination of Soil Crusts on the Floor of Jezero crater, Mars
+      </description>
+    </Citation_Information>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2022-06-23</modification_date>
+        <version_id>1.0</version_id>
+        <description>Version 1</description>
+      </Modification_Detail>
+      <Modification_Detail>
+        <modification_date>2023-03-14</modification_date>
+        <version_id>1.1</version_id>
+        <description>Version 1.1. Revised External_Reference in all XML labels.</description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Context_Area>
+    <Time_Coordinates>
+      <start_date_time>2021-06-26T00:00:00Z</start_date_time>
+      <stop_date_time>2021-06-28T23:59:59Z</stop_date_time>
+    </Time_Coordinates>
+    <Primary_Result_Summary>
+      <purpose>Science</purpose>
+      <processing_level>Derived</processing_level>
+    </Primary_Result_Summary>
+    <Investigation_Area>
+      <name>Mars 2020</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.mars2020</lid_reference>
+        <reference_type>bundle_to_investigation</reference_type>
+      </Internal_Reference>
+    </Investigation_Area>
+    <Observing_System>
+      <Observing_System_Component>
+        <name>Mars 2020</name>
+        <type>Host</type>
+        <Internal_Reference>
+          <lid_reference>urn:nasa:pds:context:instrument_host:spacecraft.mars2020</lid_reference>
+          <reference_type>is_instrument_host</reference_type>
+        </Internal_Reference>
+      </Observing_System_Component>
+      <Observing_System_Component>
+        <name>PIXL Spectrometer</name>
+        <type>Instrument</type>
+        <Internal_Reference>
+          <lid_reference>urn:nasa:pds:context:instrument:mars2020.pixl</lid_reference>
+          <reference_type>is_instrument</reference_type>
+        </Internal_Reference>
+      </Observing_System_Component>
+    </Observing_System>
+    <Target_Identification>
+      <name>Mars</name>
+      <type>Planet</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+        <reference_type>bundle_to_target</reference_type>
+      </Internal_Reference>
+    </Target_Identification>
+  </Context_Area>
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:hausrath_m2020_pixl_naltsos:document:supporting_information</lid_reference>
+      <reference_type>bundle_to_document</reference_type>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1029/2022JE007433</doi>
+      <reference_text>
+        Hausrath, E. M. et al. (2023), An Examination of Soil Crusts on the Floor of Jezero crater, Mars, Journal of Geophysical 
+        Research: Planets, doi:10.1029/2022JE007433.
+     </reference_text>
+    </External_Reference>
+  </Reference_List>
+  <Bundle>
+    <bundle_type>Archive</bundle_type>
+  </Bundle>
+  <File_Area_Text>
+    <File>
+      <file_name>readme.txt</file_name>
+    </File>
+    <Stream_Text>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>7-Bit ASCII Text</parsing_standard_id>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+    </Stream_Text>
+  </File_Area_Text>
+  <Bundle_Member_Entry>
+    <lid_reference>urn:nasa:pds:hausrath_m2020_pixl_naltsos:document</lid_reference>
+    <member_status>Primary</member_status>
+    <reference_type>bundle_has_document_collection</reference_type>
+  </Bundle_Member_Entry>
+  <Bundle_Member_Entry>
+    <lid_reference>urn:nasa:pds:hausrath_m2020_pixl_naltsos:data</lid_reference>
+    <member_status>Primary</member_status>
+    <reference_type>bundle_has_data_collection</reference_type>
+  </Bundle_Member_Entry>
+</Product_Bundle>


### PR DESCRIPTION
## 🗒️ Summary
Some of the XML files come with BOMs. Upgraded the file reading to process BOMs.

## ⚙️ Test Data and/or Report
Automated unit tests below should pass

With changes, processing the bundle after multiple harvests gives (obviously they were ingested the first time or they would not be skipped this time):
```
[SUMMARY] Reading configuration from /home/niessner/Projects/PDS/harvest/src/test/resources/github141.xml
[SUMMARY] Output directory: /tmp/harvest/out
[SUMMARY] Elasticsearch URL: https://elasticsearch:9200, index: registry
[INFO] Connecting to Elasticsearch
[INFO] Loading PDS to ES data type mapping from /home/niessner/Projects/PDS/harvest/target/classes/elastic/data-dic-types.cfg
[INFO] Loading PDS to ES data type mapping from /home/niessner/Projects/PDS/harvest/target/classes/elastic/data-dic-types.cfg
[INFO] Loading PDS to ES data type mapping from /home/niessner/Projects/PDS/harvest/target/classes/elastic/data-dic-types.cfg
[INFO] Processing bundle directory /home/niessner/Projects/PDS/harvest/src/test/resources/github141
[INFO] Processing bundle /home/niessner/Projects/PDS/harvest/src/test/resources/github141/bundle_hausrath_m2020_pixl_naltsos.xml
[WARN] Bundle urn:nasa:pds:hausrath_m2020_pixl_naltsos::1.1 already registered. Skipping.
[INFO] Processing collection /home/niessner/Projects/PDS/harvest/src/test/resources/github141/data/collection_data_inventory.xml
[WARN] Collection urn:nasa:pds:hausrath_m2020_pixl_naltsos:data::2.0 already registered. Skipping.
[INFO] Processing collection /home/niessner/Projects/PDS/harvest/src/test/resources/github141/document/collection_document_inventory.xml
[WARN] Collection urn:nasa:pds:hausrath_m2020_pixl_naltsos:document::2.0 already registered. Skipping.
[INFO] Processing products...
[INFO] Skipping product /home/niessner/Projects/PDS/harvest/src/test/resources/github141/data/oxides_bulksum.xml (LIDVID/LID is not in collection inventory or already exists in registry database)
[INFO] Skipping product /home/niessner/Projects/PDS/harvest/src/test/resources/github141/data/oxides_pmc.xml (LIDVID/LID is not in collection inventory or already exists in registry database)
[INFO] Skipping product /home/niessner/Projects/PDS/harvest/src/test/resources/github141/document/supporting_information.xml (LIDVID/LID is not in collection inventory or already exists in registry database)
[SUMMARY] Summary:
[SUMMARY] Skipped files: 6
[SUMMARY] Loaded files: 0
[SUMMARY] Failed files: 0
[SUMMARY] Package ID: f6023f49-bba5-456f-b121-e132b2d8ceae
```

## ♻️ Related Issues
Closes #141


