### PR TITLE
make arg parsing a bit more sane

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -51,7 +51,7 @@ public class HarvestCli
         if(args.length == 0)
         {
             printHelp();
-            System.exit(0);
+            System.exit(1);
         }
         
         // Version
@@ -61,16 +61,20 @@ public class HarvestCli
             System.exit(0);
         }        
 
+        for (String arg : args) {
+          if ("-h".equalsIgnoreCase(arg) || "-help".equalsIgnoreCase(arg) || "--help".equalsIgnoreCase(arg) || "?".equalsIgnoreCase(arg)) {
+            printHelp();
+          }
+        }
+
         if(!parse(args))
         {
-            System.out.println();
-            printHelp();
-            System.exit(1);
+            System.exit(2);
         }
 
         if(!runCommand())
         {
-            System.exit(1);
+            System.exit(3);
         }        
     }
     

--- a/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -64,6 +64,7 @@ public class HarvestCli
         for (String arg : args) {
           if ("-h".equalsIgnoreCase(arg) || "-help".equalsIgnoreCase(arg) || "--help".equalsIgnoreCase(arg) || "?".equalsIgnoreCase(arg)) {
             printHelp();
+            System.exit(0);
           }
         }
 


### PR DESCRIPTION
## 🗒️ Summary
Updated arg parsing to behave a touch more sanely and match desired behavior.

## ⚙️ Test Data and/or Report
```
harvest --help
Usage: harvest <options>

Commands:
  -c <config file>   Crawl file system and process PDS4 labels
  -V, --version      Print Harvest version

Optional parameters:
  -o <dir>              Output directory (applies to supplemental products only).
                        Default is /tmp/harvest/out
  -l <file>             Log file. Default is /tmp/harvest/harvest.log
  -v <level>            Logger verbosity: DEBUG, INFO (default), WARNING, ERROR
  -O, --overwrite       Overwrite registered products
  -a, --archive-status  Set the archive status for all products defaulting to staged
     archived
     certified
     restricted
     staged
```

```
harvest --apple
ERROR] Unrecognized option: --apple
```

## ♻️ Related Issues
Closes #199 

