### PR TITLE
changes for common log4j

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/util/log/Log4jConfigurator.java
+++ b/src/main/java/gov/nasa/pds/harvest/util/log/Log4jConfigurator.java
@@ -56,7 +56,7 @@ public class Log4jConfigurator
     {
         AppenderComponentBuilder appender = cfg.newAppender(name, "CONSOLE");
         appender.addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
-        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "[%level] %msg%n%throwable"));
+        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss} [%-5p] (%F:%M:%L) %m%n%throwable"));
         cfg.add(appender);
     }
     
@@ -74,7 +74,7 @@ public class Log4jConfigurator
         AppenderComponentBuilder appender = cfg.newAppender(name, "FILE");
         appender.addAttribute("fileName", filePath);
         appender.addAttribute("append", false);
-        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d [%level] %msg%n%throwable"));
+        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss} [%-5p] (%F:%M:%L) %m%n%throwable"));
         cfg.add(appender);
     }
     


### PR DESCRIPTION
## 🗒️ Summary
Updated to latest log4j pattern.

## ⚙️ Test Data and/or Report
Log now looks like:
```
2024-11-14 10:24:50 [INFO ] (FileDownloader.java:download:79) 404 - Not Found
2024-11-14 10:24:50 [INFO ] (FileDownloader.java:download:82) Will retry in 5 seconds
2024-11-14 10:24:55 [INFO ] (FileDownloader.java:downloadOnce:106) Downloading https://pds.nasa.gov/pds4/mission/insight/v1/PDS4_INSIGHT_1A10_1830.JSON to /tmp/LDD-17278595985076089148.JSON
```

## ♻️ Related Issues
Partial #203 