### PR TITLE
update "unsupported registry index name" error message to provide additional useful information

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/cfg/ConfigManager.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/ConfigManager.java
@@ -59,8 +59,11 @@ public class ConfigManager
       return lidvids;
     }
     static public String exchangeIndexForNode (String indexName) {
-      if (indexNodeMap.containsKey (indexName)) return indexNodeMap.get(indexName);
+      if (!indexNodeMap.containsKey (indexName)) {
         throw new IllegalArgumentException("Index \"" + indexName + "\" is not one of the supported indices (\"" + String.join("\", \"", indexNodeMap.keySet()) + "\"): use a supported index name in your configuration or request that index \"" + indexName + "\" be added to harvest by submitting a ticket on https://github.com/NASA-PDS/harvest/issues");
+      }
+
+      return indexNodeMap.get(indexName);
     }
     static public ConnectionFactory exchangeRegistry (RegistryType xml) throws Exception {
       return EstablishConnectionFactory.from (xml.getValue(), xml.getAuth());

--- a/src/main/java/gov/nasa/pds/harvest/cfg/ConfigManager.java
+++ b/src/main/java/gov/nasa/pds/harvest/cfg/ConfigManager.java
@@ -60,7 +60,7 @@ public class ConfigManager
     }
     static public String exchangeIndexForNode (String indexName) {
       if (indexNodeMap.containsKey (indexName)) return indexNodeMap.get(indexName);
-      throw new IllegalArgumentException("Index (" + indexName + ") + not supported: either fix it in your configuration by using one of the supported or request an upgrade of harvest to support your new index by submitting a ticket on https://github.com/NASA-PDS/harvest/issues");
+        throw new IllegalArgumentException("Index \"" + indexName + "\" is not one of the supported indices (\"" + String.join("\", \"", indexNodeMap.keySet()) + "\"): use a supported index name in your configuration or request that index \"" + indexName + "\" be added to harvest by submitting a ticket on https://github.com/NASA-PDS/harvest/issues");
     }
     static public ConnectionFactory exchangeRegistry (RegistryType xml) throws Exception {
       return EstablishConnectionFactory.from (xml.getValue(), xml.getAuth());


### PR DESCRIPTION

## 🗒️ Summary
Previously, error would report that value was not in the list of valid values, but not what those values _are_.

New message spits out the supported values enumeration.

## ⚙️ Test Data and/or Report
Manually tested with invalid index name in configuration - scope is small enough that that should be sufficient.

## ♻️ Related Issues
Fixes #233 


