### PR TITLE
Make duplicate LIDVID a debug message since it is induced by the retry policy, not by actual duplicated LIDVIDs

### DIFF
--- a/src/main/java/gov/nasa/pds/harvest/dao/RegistryDocBatch.java
+++ b/src/main/java/gov/nasa/pds/harvest/dao/RegistryDocBatch.java
@@ -126,11 +126,11 @@ public class RegistryDocBatch {
     for (Entry<String, Integer> entry : history.entrySet()) {
       if (entry.getValue() > 1) {
         if (first) {
-          log.fatal(
+          log.debug(
               "The harvested collection has duplicate lidvids. Double check content of these lidvids:");
           first = false;
         }
-        log.fatal("   Found " + entry.getValue() + " of lidvid " + entry.getKey());
+        log.debug("   Found " + entry.getValue() + " of lidvid " + entry.getKey());
       }
     }
     if (!first) {
@@ -138,7 +138,7 @@ public class RegistryDocBatch {
       for (Integer count : history.values()) {
         total += count;
       }
-      log.fatal("   Total number of duplicate lidvids: " + (total - history.size()));
+      log.debug("   Total number of duplicate lidvids: " + (total - history.size()));
     }
   }
 }


### PR DESCRIPTION
## 🗒️ Summary
Set the message level correctly.

## ⚙️ Test Data and/or Report
NA - simply changed level of message (no behavioral changes)

## ♻️ Related Issues
Closes #285 


